### PR TITLE
Refactor graph editor

### DIFF
--- a/true-self-sim/front/src/component/EditableNode.tsx
+++ b/true-self-sim/front/src/component/EditableNode.tsx
@@ -1,0 +1,97 @@
+import { memo, useState } from 'react';
+import { Handle, Position } from 'reactflow';
+
+export interface NodeFormData {
+    sceneId: string;
+    speaker: string;
+    backgroundImage: string;
+    text: string;
+    start: boolean;
+    end: boolean;
+}
+
+export interface EditableNodeData extends NodeFormData {
+    onUpdate: (id: string, data: NodeFormData) => void;
+}
+
+export interface EditableNodeProps {
+    id: string;
+    data: EditableNodeData;
+    selected: boolean;
+}
+
+const EditableNode: React.FC<EditableNodeProps> = memo(({ id, data, selected }) => {
+    const [editMode, setEditMode] = useState(false);
+    const [fields, setFields] = useState<NodeFormData>({
+        sceneId: data.sceneId,
+        speaker: data.speaker,
+        backgroundImage: data.backgroundImage,
+        text: data.text,
+        start: data.start,
+        end: data.end,
+    });
+
+    const onDoubleClick = () => setEditMode(true);
+
+    const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value, type, checked } = e.target;
+        setFields({ ...fields, [name]: type === 'checkbox' ? checked : value });
+    };
+
+    const onSave = () => {
+        data.onUpdate(id, fields);
+        setEditMode(false);
+    };
+
+    return (
+        <div
+            onDoubleClick={onDoubleClick}
+            style={{
+                padding: 10,
+                border: selected ? '2px solid #007aff' : '1px solid #777',
+                borderRadius: 5,
+                background: '#fff',
+                width: 180,
+            }}
+        >
+            <Handle type="target" position={Position.Top} style={{ background: '#555' }} />
+            {editMode ? (
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <input name="sceneId" value={fields.sceneId} onChange={onChange} placeholder="sceneId" />
+                    <input name="speaker" value={fields.speaker} onChange={onChange} placeholder="speaker" />
+                    <input name="backgroundImage" value={fields.backgroundImage} onChange={onChange} placeholder="backgroundImage" />
+                    <textarea name="text" value={fields.text} onChange={onChange} rows={3} placeholder="text" />
+                    <label style={{ fontSize: 12 }}>
+                        <input type="checkbox" name="start" checked={fields.start} onChange={onChange} /> Start
+                    </label>
+                    <label style={{ fontSize: 12 }}>
+                        <input type="checkbox" name="end" checked={fields.end} onChange={onChange} /> End
+                    </label>
+                    <button
+                        onClick={onSave}
+                        disabled={
+                            !fields.sceneId.trim() ||
+                            !fields.speaker.trim() ||
+                            !fields.backgroundImage.trim() ||
+                            !fields.text.trim()
+                        }
+                        className="mt-1 px-2 py-1 rounded bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        Save
+                    </button>
+                </div>
+            ) : (
+                <div>
+                    <strong>{data.sceneId}</strong>
+                    <div style={{ fontStyle: 'italic', fontSize: 12 }}>{data.speaker}</div>
+                    <div style={{ fontSize: 12, marginTop: 4 }}>{data.text}</div>
+                    {data.start && <div style={{ color: 'green', fontSize: 10 }}>Start</div>}
+                    {data.end && <div style={{ color: 'red', fontSize: 10 }}>End</div>}
+                </div>
+            )}
+            <Handle type="source" position={Position.Bottom} id="source" style={{ background: '#555' }} />
+        </div>
+    );
+});
+
+export default EditableNode;

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -1,90 +1,26 @@
-import React, { useState, useCallback, useRef, memo } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import ReactFlow, {
     MiniMap,
     Controls,
     Background,
     addEdge,
-    applyNodeChanges,
-    applyEdgeChanges,
     MarkerType,
-    Handle,
-    Position,
+    ReactFlowProvider,
+    useNodesState,
+    useEdgesState,
 } from 'reactflow';
 import type {
     Node as FlowNode,
     Edge as FlowEdge,
     Connection,
-    NodeChange,
-    EdgeChange,
     Selection,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-// Custom editable node with handles
-const EditableNode = memo(({ id, data, selected }: any) => {
-    const [editMode, setEditMode] = useState(false);
-    const [fields, setFields] = useState({ ...data });
-    const onDoubleClick = () => setEditMode(true);
-    const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        const { name, value, type, checked } = e.target;
-        setFields({ ...fields, [name]: type === 'checkbox' ? checked : value });
-    };
-
-    const onSave = () => {
-        data.onUpdate(id, fields);
-        setEditMode(false);
-    };
-
-    return (
-        <div
-            onDoubleClick={onDoubleClick}
-            style={{
-                padding: 10,
-                border: selected ? '2px solid #007aff' : '1px solid #777',
-                borderRadius: 5,
-                background: '#fff',
-                width: 180,
-            }}
-        >
-            <Handle type="target" position={Position.Top} style={{ background: '#555' }} />
-            {editMode ? (
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <input name="sceneId" value={fields.sceneId} onChange={onChange} placeholder="sceneId" />
-                    <input name="speaker" value={fields.speaker} onChange={onChange} placeholder="speaker" />
-                    <input name="backgroundImage" value={fields.backgroundImage} onChange={onChange} placeholder="backgroundImage" />
-                    <textarea name="text" value={fields.text} onChange={onChange} rows={3} placeholder="text" />
-                    <label style={{ fontSize: 12 }}>
-                        <input type="checkbox" name="start" checked={fields.start} onChange={onChange} /> Start
-                    </label>
-                    <label style={{ fontSize: 12 }}>
-                        <input type="checkbox" name="end" checked={fields.end} onChange={onChange} /> End
-                    </label>
-                    <button
-                        onClick={onSave}
-                        disabled={
-                            !fields.sceneId.trim() ||
-                            !fields.speaker.trim() ||
-                            !fields.backgroundImage.trim() ||
-                            !fields.text.trim()
-                        }
-                        className="mt-1 px-2 py-1 rounded bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                        Save
-                    </button>
-                </div>
-            ) : (
-                <div>
-                    <strong>{data.sceneId}</strong>
-                    <div style={{ fontStyle: 'italic', fontSize: 12 }}>{data.speaker}</div>
-                    <div style={{ fontSize: 12, marginTop: 4 }}>{data.text}</div>
-                    {data.start && <div style={{ color: 'green', fontSize: 10 }}>Start</div>}
-                    {data.end && <div style={{ color: 'red', fontSize: 10 }}>End</div>}
-                </div>
-            )}
-            <Handle type="source" position={Position.Bottom} id="source" style={{ background: '#555' }} />
-        </div>
-    );
-});
+import EditableNode, {
+    EditableNodeData,
+    NodeFormData,
+} from '../component/EditableNode';
 
 const nodeTypes = { editableNode: EditableNode };
 
@@ -92,9 +28,9 @@ interface ChoiceRequest { text: string; nextSceneId: string; }
 interface Scene { sceneId: string; speaker: string; backgroundImage: string; text: string; start: boolean; end: boolean; choiceRequests: ChoiceRequest[]; }
 
 // Convert nodes and edges to JSON
-const exportAsScenes = (nodes: FlowNode[], edges: FlowEdge[]): Scene[] =>
+const exportAsScenes = (nodes: FlowNode<EditableNodeData>[], edges: FlowEdge[]): Scene[] =>
     nodes.map((node) => {
-        const data: any = node.data;
+        const data = node.data;
         const outgoing = edges.filter((e) => e.source === node.id);
         return {
             sceneId: data.sceneId,
@@ -109,8 +45,8 @@ const exportAsScenes = (nodes: FlowNode[], edges: FlowEdge[]): Scene[] =>
 
 const PublicAdminGraph: React.FC = () => {
     const idCounter = useRef(1);
-    const [nodes, setNodes] = useState<FlowNode[]>([]);
-    const [edges, setEdges] = useState<FlowEdge[]>([]);
+    const [nodes, setNodes, onNodesChange] = useNodesState<EditableNodeData>([]);
+    const [edges, setEdges, onEdgesChange] = useEdgesState([]);
     const [selection, setSelection] = useState<Selection>({ nodes: [], edges: [] });
     const [edgeLabel, setEdgeLabel] = useState('');
 
@@ -120,7 +56,7 @@ const PublicAdminGraph: React.FC = () => {
         setNodes([{ id: initialId, type: 'editableNode', position: { x: 50, y: 50 }, data: { sceneId: initialId, speaker: '', backgroundImage: '', text: '', start: true, end: false, onUpdate: handleNodeUpdate } }]);
     }, []);
 
-    function handleNodeUpdate(id: string, newData: any) {
+    function handleNodeUpdate(id: string, newData: NodeFormData) {
         setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, data: { ...newData, onUpdate: handleNodeUpdate } } : n)));
     }
 
@@ -142,8 +78,6 @@ const PublicAdminGraph: React.FC = () => {
         setEdges((eds) => addEdge({ ...connection, label: '' , markerEnd: { type: MarkerType.ArrowClosed } }, eds));
     }, []);
 
-    const onNodesChange = useCallback((changes: NodeChange[]) => setNodes((nds) => applyNodeChanges(changes, nds)), []);
-    const onEdgesChange = useCallback((changes: EdgeChange[]) => setEdges((eds) => applyEdgeChanges(changes, eds)), []);
     const onSelectionChange = useCallback((sel: Selection) => {
         setSelection(sel);
         if (sel.edges.length === 1) setEdgeLabel(sel.edges[0].label as string || '');
@@ -172,6 +106,7 @@ const PublicAdminGraph: React.FC = () => {
     };
 
     return (
+        <ReactFlowProvider>
         <div style={{ width: '100%', height: '100vh', position: 'relative' }}>
             <div style={{ position: 'absolute', zIndex: 10, top: 10, left: 10, background: 'rgba(255,255,255,0.9)', padding: 8, borderRadius: 4 }}>
                 <button onClick={handleAddScene} style={{ marginRight: 8 }}>New Scene</button>
@@ -200,6 +135,7 @@ const PublicAdminGraph: React.FC = () => {
                 <Background />
             </ReactFlow>
         </div>
+        </ReactFlowProvider>
     );
 };
 

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -17,10 +17,8 @@ import type {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-import EditableNode, {
-    EditableNodeData,
-    NodeFormData,
-} from '../component/EditableNode';
+import EditableNode from '../component/EditableNode';
+import type { EditableNodeData, NodeFormData } from '../component/EditableNode';
 
 const nodeTypes = { editableNode: EditableNode };
 


### PR DESCRIPTION
## Summary
- migrate graph editing to `useNodesState` and `useEdgesState`
- wrap `PublicAdminGraph` with `ReactFlowProvider`
- create dedicated `EditableNode` component with explicit props

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6859e257c6548323b1fbd4fef986d0b3