### PR TITLE
Update graph node logic

### DIFF
--- a/true-self-sim/front/src/component/EditableNode.tsx
+++ b/true-self-sim/front/src/component/EditableNode.tsx
@@ -61,12 +61,6 @@ const EditableNode: React.FC<EditableNodeProps> = memo(({ id, data, selected }) 
                     <input name="speaker" value={fields.speaker} onChange={onChange} placeholder="speaker" />
                     <input name="backgroundImage" value={fields.backgroundImage} onChange={onChange} placeholder="backgroundImage" />
                     <textarea name="text" value={fields.text} onChange={onChange} rows={3} placeholder="text" />
-                    <label style={{ fontSize: 12 }}>
-                        <input type="checkbox" name="start" checked={fields.start} onChange={onChange} /> Start
-                    </label>
-                    <label style={{ fontSize: 12 }}>
-                        <input type="checkbox" name="end" checked={fields.end} onChange={onChange} /> End
-                    </label>
                     <button
                         onClick={onSave}
                         disabled={

--- a/true-self-sim/front/src/component/EditableNode.tsx
+++ b/true-self-sim/front/src/component/EditableNode.tsx
@@ -31,7 +31,10 @@ const EditableNode: React.FC<EditableNodeProps> = memo(({ id, data, selected }) 
         end: data.end,
     });
 
-    const onDoubleClick = () => setEditMode(true);
+    const onDoubleClick = () => {
+        setFields({ ...data });
+        setEditMode(true);
+    };
 
     const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value, type, checked } = e.target;

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -96,6 +96,21 @@ const PublicAdminGraph: React.FC = () => {
         setNodes((nds) => nds.concat({ id: newId, type: 'editableNode', position: { x: 100, y: 100 }, data: { sceneId: newId, speaker: '', backgroundImage: '', text: '', start: false, end: false, onUpdate: handleNodeUpdate } }));
     };
 
+    // keep end flag in sync with outgoing edges and enforce single start node
+    React.useEffect(() => {
+        setNodes((nds) => {
+            if (nds.length === 0) return nds;
+            const firstId = nds[0].id;
+            return nds.map((n) => {
+                const hasOutgoing = edges.some((e) => e.source === n.id);
+                const shouldStart = n.id === firstId;
+                const shouldEnd = !hasOutgoing;
+                if (n.data.start === shouldStart && n.data.end === shouldEnd) return n;
+                return { ...n, data: { ...n.data, start: shouldStart, end: shouldEnd } };
+            });
+        });
+    }, [edges, nodes.length]);
+
     const handleExport = () => {
         const scenes = exportAsScenes(nodes, edges);
         const blob = new Blob([JSON.stringify(scenes, null, 2)], { type: 'application/json' });


### PR DESCRIPTION
## Summary
- update PublicAdminGraph to auto-set end/start flags based on edges
- remove start/end checkboxes from EditableNode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6859e91b8048832384a59cb2a9a2340c