### PR TITLE
Fix editable node start/end syncing

### DIFF
--- a/true-self-sim/front/src/component/EditableNode.tsx
+++ b/true-self-sim/front/src/component/EditableNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useState, useEffect } from 'react';
 import { Handle, Position } from 'reactflow';
 
 export interface NodeFormData {
@@ -30,6 +30,11 @@ const EditableNode: React.FC<EditableNodeProps> = memo(({ id, data, selected }) 
         start: data.start,
         end: data.end,
     });
+
+    // Keep local state in sync when start or end flags change externally
+    useEffect(() => {
+        setFields((prev) => ({ ...prev, start: data.start, end: data.end }));
+    }, [data.start, data.end]);
 
     const onDoubleClick = () => setEditMode(true);
 

--- a/true-self-sim/front/src/component/EditableNode.tsx
+++ b/true-self-sim/front/src/component/EditableNode.tsx
@@ -36,7 +36,17 @@ const EditableNode: React.FC<EditableNodeProps> = memo(({ id, data, selected }) 
         setFields((prev) => ({ ...prev, start: data.start, end: data.end }));
     }, [data.start, data.end]);
 
-    const onDoubleClick = () => setEditMode(true);
+    const onDoubleClick = () => {
+        setFields({
+            sceneId: data.sceneId,
+            speaker: data.speaker,
+            backgroundImage: data.backgroundImage,
+            text: data.text,
+            start: data.start,
+            end: data.end,
+        });
+        setEditMode(true);
+    };
 
     const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value, type, checked } = e.target;


### PR DESCRIPTION
## Summary
- keep EditableNode fields in sync with updated start/end props

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6859ed1169fc83239f7faa9ac965743a