### PR TITLE
Overlay retrospective in PublicGame

### DIFF
--- a/true-self-sim/front/src/pages/PublicGame.tsx
+++ b/true-self-sim/front/src/pages/PublicGame.tsx
@@ -65,7 +65,7 @@ const PublicGame: React.FC = () => {
                 <>
                     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40" />
                     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                        <Retrospective log={log} onRestart={handleRestart} />
+                        <Retrospective log={log} finalText={scene.text} onRestart={handleRestart} />
                     </div>
                 </>
             )}

--- a/true-self-sim/front/src/pages/PublicGame.tsx
+++ b/true-self-sim/front/src/pages/PublicGame.tsx
@@ -53,19 +53,22 @@ const PublicGame: React.FC = () => {
 
     const bgSrc = isExternalUrl(scene.backgroundImage) ? scene.backgroundImage : `background/${scene.backgroundImage}`;
 
-    if (isFinished) {
-        return (
-            <Retrospective log={log} onRestart={() => {
-                setLog([]);
-                setIsFinished(false);
-                if (firstScene) setScene(firstScene);
-            }}
-            />
-        )
-    }
+    const handleRestart = () => {
+        setLog([]);
+        setIsFinished(false);
+        if (firstScene) setScene(firstScene);
+    };
 
     return (
         <div className="relative min-h-screen w-full overflow-hidden bg-black text-white flex flex-col md:flex-row">
+            {isFinished && (
+                <>
+                    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40" />
+                    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                        <Retrospective log={log} onRestart={handleRestart} />
+                    </div>
+                </>
+            )}
             <img className="absolute inset-0 w-full h-full object-cover opacity-50" alt="background"
                  src={bgSrc}
             />

--- a/true-self-sim/front/src/pages/Retrospective.tsx
+++ b/true-self-sim/front/src/pages/Retrospective.tsx
@@ -1,8 +1,11 @@
 import type {RetrospectiveProps} from "../props.ts";
 
-export const Retrospective: React.FC<RetrospectiveProps> = ({ log, onRestart }) => {
+export const Retrospective: React.FC<RetrospectiveProps> = ({ log, onRestart, finalText }) => {
     return (
         <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-8 max-w-xl w-full space-y-6 text-white">
+            {finalText && (
+                <p className="text-lg mb-4">{finalText}</p>
+            )}
             <h2 className="text-2xl font-bold text-indigo-300">당신의 여정</h2>
             <ul className="list-decimal list-inside space-y-1 text-sm max-h-60 overflow-auto">
                 {log.map((entry, index) => (

--- a/true-self-sim/front/src/pages/Retrospective.tsx
+++ b/true-self-sim/front/src/pages/Retrospective.tsx
@@ -2,22 +2,20 @@ import type {RetrospectiveProps} from "../props.ts";
 
 export const Retrospective: React.FC<RetrospectiveProps> = ({ log, onRestart }) => {
     return (
-        <div className="min-h-screen bg-black text-white flex items-center justify-center">
-            <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-8 max-w-xl w-full space-y-6">
-                <h2 className="text-2xl font-bold text-indigo-300">당신의 여정</h2>
-                <ul className="list-decimal list-inside space-y-1 text-sm max-h-60 overflow-auto">
-                    {log.map((entry, index) => (
-                        <li key={index}>{entry}</li>
-                    ))}
-                </ul>
+        <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-8 max-w-xl w-full space-y-6 text-white">
+            <h2 className="text-2xl font-bold text-indigo-300">당신의 여정</h2>
+            <ul className="list-decimal list-inside space-y-1 text-sm max-h-60 overflow-auto">
+                {log.map((entry, index) => (
+                    <li key={index}>{entry}</li>
+                ))}
+            </ul>
 
-                <button
-                    onClick={onRestart}
-                    className="w-full py-2 mt-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-white"
-                >
-                    처음부터 다시 시작
-                </button>
-            </div>
+            <button
+                onClick={onRestart}
+                className="w-full py-2 mt-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-white"
+            >
+                처음부터 다시 시작
+            </button>
         </div>
     );
 };

--- a/true-self-sim/front/src/props.ts
+++ b/true-self-sim/front/src/props.ts
@@ -4,5 +4,7 @@ export interface MemoryLogProps {
 
 export interface RetrospectiveProps {
     log: string[];
+    /** 마지막 씬에서 보여줄 텍스트 */
+    finalText?: string;
     onRestart: () => void; // ← 여기 중요!
 }


### PR DESCRIPTION
## Summary
- always render game view in PublicGame
- show Retrospective as an overlay when finished
- simplify Retrospective component for modal usage

## Testing
- `npm run build` *(fails: Cannot find module '@eslint/js')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859f5497d8883239a3c24904f162a62