### PR TITLE
Add full log view to PublicGame

### DIFF
--- a/true-self-sim/front/src/component/FullLog.tsx
+++ b/true-self-sim/front/src/component/FullLog.tsx
@@ -1,0 +1,24 @@
+import type { FullLogProps } from "../props.ts";
+
+const FullLog: React.FC<FullLogProps> = ({ log, onRestart }) => {
+    return (
+        <div className="flex flex-col items-center space-y-4 w-full">
+            <div className="bg-white/10 backdrop-blur-md rounded-xl p-6 w-full max-w-xl max-h-[70vh] overflow-y-auto text-sm">
+                <h2 className="text-indigo-300 font-bold mb-2">전체 로그</h2>
+                <ul className="list-decimal list-inside space-y-1">
+                    {log.map((entry, idx) => (
+                        <li key={idx}>{entry}</li>
+                    ))}
+                </ul>
+            </div>
+            <button
+                onClick={onRestart}
+                className="py-2 px-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-white"
+            >
+                처음으로 돌아가기
+            </button>
+        </div>
+    );
+};
+
+export default FullLog;

--- a/true-self-sim/front/src/pages/PublicGame.tsx
+++ b/true-self-sim/front/src/pages/PublicGame.tsx
@@ -93,32 +93,34 @@ const PublicGame: React.FC = () => {
                         )}
                     </div>
                 </div>
-                {isFinished ? (
-                    <FullLog log={fullLog} onRestart={() => {
-                        setLog([]);
-                        setFullLog([]);
-                        setIsFinished(false);
-                        if (firstScene) setScene(firstScene);
-                    }} />
-                ) : (
-                    <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-6 w-full max-w-xl md:max-w-2xl">
-                        <h2 className="text-indigo-300 text-lg md:text-xl mb-2">
-                            {scene.speaker}
-                        </h2>
-                        <p className="text-xl md:text-2xl mb-4">
-                            {scene.text}
-                        </p>
-                        <div className="space-y-2">
-                            {scene?.texts?.map((t, index) => (
-                                <button className="block w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm md:text-base"
-                                        key={index}
-                                        onClick={() => handleNextScene(t.nextPublicSceneId, t.text)}
-                                >
-                                    {t.text}
-                                </button>
-                            ))}
-                        </div>
+                <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-6 w-full max-w-xl md:max-w-2xl">
+                    <h2 className="text-indigo-300 text-lg md:text-xl mb-2">
+                        {scene.speaker}
+                    </h2>
+                    <p className="text-xl md:text-2xl mb-4">
+                        {scene.text}
+                    </p>
+                    <div className="space-y-2">
+                        {scene?.texts?.map((t, index) => (
+                            <button className="block w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm md:text-base"
+                                    key={index}
+                                    onClick={() => handleNextScene(t.nextPublicSceneId, t.text)}
+                            >
+                                {t.text}
+                            </button>
+                        ))}
                     </div>
+                </div>
+                {isFinished && (
+                    <FullLog
+                        log={fullLog}
+                        onRestart={() => {
+                            setLog([]);
+                            setFullLog([]);
+                            setIsFinished(false);
+                            if (firstScene) setScene(firstScene);
+                        }}
+                    />
                 )}
             </div>
             {!isFinished && (

--- a/true-self-sim/front/src/pages/Retrospective.tsx
+++ b/true-self-sim/front/src/pages/Retrospective.tsx
@@ -1,23 +1,10 @@
-import type {RetrospectiveProps} from "../props.ts";
+import type { RetrospectiveProps } from "../props.ts";
+import FullLog from "../component/FullLog.tsx";
 
 export const Retrospective: React.FC<RetrospectiveProps> = ({ log, onRestart }) => {
     return (
         <div className="min-h-screen bg-black text-white flex items-center justify-center">
-            <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-8 max-w-xl w-full space-y-6">
-                <h2 className="text-2xl font-bold text-indigo-300">당신의 여정</h2>
-                <ul className="list-decimal list-inside space-y-1 text-sm max-h-60 overflow-auto">
-                    {log.map((entry, index) => (
-                        <li key={index}>{entry}</li>
-                    ))}
-                </ul>
-
-                <button
-                    onClick={onRestart}
-                    className="w-full py-2 mt-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-white"
-                >
-                    처음부터 다시 시작
-                </button>
-            </div>
+            <FullLog log={log} onRestart={onRestart} />
         </div>
     );
 };

--- a/true-self-sim/front/src/props.ts
+++ b/true-self-sim/front/src/props.ts
@@ -2,6 +2,11 @@ export interface MemoryLogProps {
     log: string[];
 }
 
+export interface FullLogProps {
+    log: string[];
+    onRestart: () => void;
+}
+
 export interface RetrospectiveProps {
     log: string[];
     onRestart: () => void; // ← 여기 중요!


### PR DESCRIPTION
## Summary
- create `FullLog` component to show the full conversation log
- refactor `PublicGame` to render `FullLog` once finished
- keep short `MemoryLog` but store full log separately
- simplify `Retrospective` page by reusing `FullLog`
- define new props for full log component

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859f7a9d82083239d41f7421f324210