### PR TITLE
Reorder log output pairwise

### DIFF
--- a/true-self-sim/front/src/component/FullLog.tsx
+++ b/true-self-sim/front/src/component/FullLog.tsx
@@ -1,12 +1,21 @@
 import type { FullLogProps } from "../props.ts";
 
+function pairwiseReverse(log: string[]): string[] {
+    const result: string[] = [];
+    for (let i = log.length - 2; i >= 0; i -= 2) {
+        result.push(log[i], log[i + 1]);
+    }
+    return result;
+}
+
 const FullLog: React.FC<FullLogProps> = ({ log, onRestart }) => {
+    const ordered = pairwiseReverse(log);
     return (
         <div className="flex flex-col items-center space-y-4 w-full">
             <div className="bg-white/10 backdrop-blur-md rounded-xl p-6 w-full max-w-xl max-h-[70vh] overflow-y-auto text-sm">
                 <h2 className="text-indigo-300 font-bold mb-2">전체 로그</h2>
                 <ul className="list-decimal list-inside space-y-1">
-                    {log.map((entry, idx) => (
+                    {ordered.map((entry, idx) => (
                         <li key={idx}>{entry}</li>
                     ))}
                 </ul>


### PR DESCRIPTION
## Summary
- add a `pairwiseReverse` helper in `FullLog`
- use reordered log when rendering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859fd1b4ec48323af5a5b07a9eab7b0