### PR TITLE
Update k8s configs to use port 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Project Setup
+
+This repository contains both backend and frontend applications. Test suites are available for each component.
+
+## Running Tests
+
+- **Backend**: Navigate to the `back` directory and execute `./gradlew test`.
+- **Frontend**: Navigate to the `front` directory and run `npm test`.
+
+Currently, there is no `AGENTS.md` file in the repository root.

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: backend-image
+          ports:
+            - containerPort: 8000
+          env:
+            - name: SERVER_PORT
+              value: "8000"

--- a/k8s/backend-service.yaml
+++ b/k8s/backend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/k8s/frontend-config.yaml
+++ b/k8s/frontend-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+data:
+  VITE_API_URL: "http://lietzsche.iptime.org:8000/"


### PR DESCRIPTION
## Summary
- add k8s deployment, service and configMap using port 8000
- document how to run tests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a084c23388323b3c4487b896e48c6