### PR TITLE
Expose k8s services via NodePort

### DIFF
--- a/true-self-sim/k8s/backend-service.yaml
+++ b/true-self-sim/k8s/backend-service.yaml
@@ -3,9 +3,11 @@ kind: Service
 metadata:
   name: backend
 spec:
+  type: NodePort
   selector:
     app: backend
   ports:
     - protocol: TCP
       port: 8000
       targetPort: 8000
+      nodePort: 30000

--- a/true-self-sim/k8s/frontend-service.yaml
+++ b/true-self-sim/k8s/frontend-service.yaml
@@ -3,7 +3,9 @@ kind: Service
 metadata:
   name: frontend
 spec:
+  type: NodePort
   ports:
     - port: 80
+      nodePort: 30080
   selector:
     app: frontend


### PR DESCRIPTION
## Summary
- expose frontend and backend services via NodePort

## Testing
- `kubectl apply -f k8s/` *(fails: `kubectl` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e1309ac8323ba740134fdbb49aa