### PR TITLE
Update backend port to 8080

### DIFF
--- a/true-self-sim/k8s/backend-deployment.yaml
+++ b/true-self-sim/k8s/backend-deployment.yaml
@@ -42,4 +42,4 @@ spec:
               name: postgres-secret
               key: POSTGRES_PASSWORD
         ports:
-        - containerPort: 8000
+        - containerPort: 8080

--- a/true-self-sim/k8s/backend-service.yaml
+++ b/true-self-sim/k8s/backend-service.yaml
@@ -8,6 +8,6 @@ spec:
     app: backend
   ports:
     - protocol: TCP
-      port: 8000
-      targetPort: 8000
+      port: 8080
+      targetPort: 8080
       nodePort: 30000


### PR DESCRIPTION
## Summary
- use port 8080 for backend container
- expose backend service on port 8080

## Testing
- `grep -n "port" k8s/backend-service.yaml`


------
https://chatgpt.com/codex/tasks/task_e_685a1562709083238faf6afe66f2a653