### PR TITLE
Add nginx SPA config for front

### DIFF
--- a/true-self-sim/front/Dockerfile
+++ b/true-self-sim/front/Dockerfile
@@ -9,5 +9,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/true-self-sim/front/nginx.conf
+++ b/true-self-sim/front/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri /index.html;
+    }
+    error_page 404 /index.html;
+}


### PR DESCRIPTION
## Summary
- add `front/nginx.conf` with a single server block to support SPA routing
- copy the new config in the front Dockerfile

## Testing
- `docker compose up -d --build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a269243c88323ace9de00a2f34550