### PR TITLE
Add validation feedback to graph editor

### DIFF
--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -74,6 +74,8 @@ const PublicAdminGraph: React.FC = () => {
     const { data } = usePublicStory();
     const { mutate: saveBulk, isPending } = usePostPublicSceneBulk();
     const { mutate: deletePublicScene, isPending: isDeletePending } = useDeletePublicScene();
+    const [errorMsg, setErrorMsg] = useState('');
+    const [successMsg, setSuccessMsg] = useState('');
     const navigate = useNavigate();
 
     const handleNodeUpdate = useCallback((id: string, newData: NodeFormData) => {
@@ -183,8 +185,30 @@ const PublicAdminGraph: React.FC = () => {
     };
 
     const handleSave = () => {
+        setErrorMsg('');
+        setSuccessMsg('');
         const requests = toRequests(nodes, edges);
-        saveBulk(requests);
+
+        for (const scene of requests) {
+            if (
+                !scene.sceneId.trim() ||
+                !scene.speaker.trim() ||
+                !scene.backgroundImage.trim() ||
+                !scene.text.trim()
+            ) {
+                setErrorMsg('모든 필수 항목을 입력해주세요.');
+                return;
+            }
+            if (scene.choiceRequests.some(cr => !cr.text.trim() || !cr.nextSceneId)) {
+                setErrorMsg('모든 필수 항목을 입력해주세요.');
+                return;
+            }
+        }
+
+        saveBulk(requests, {
+            onError: () => setErrorMsg('장면 저장에 실패했습니다.'),
+            onSuccess: () => setSuccessMsg('장면 저장에 성공했습니다.'),
+        });
     };
 
     return (
@@ -195,6 +219,8 @@ const PublicAdminGraph: React.FC = () => {
                 <button onClick={handleAddScene} style={{ marginRight: 8 }}>New Scene</button>
                 <button onClick={handleExport} style={{ marginRight: 8 }}>Export JSON</button>
                 <button onClick={handleSave} style={{ marginRight: 8 }} disabled={isPending}>Save</button>
+                {errorMsg && <span style={{ color: 'red', marginRight: 8 }}>{errorMsg}</span>}
+                {successMsg && <span style={{ color: 'green', marginRight: 8 }}>{successMsg}</span>}
                 <button
                     onClick={handleDeleteScene}
                     disabled={selection.nodes.length === 0 || isDeletePending}


### PR DESCRIPTION
## Summary
- add `errorMsg` and `successMsg` state variables in `PublicAdminGraph`
- validate mandatory fields before saving scenes
- show success or error messages next to the Save button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685a49a4ab688323a99d3bf445de5d64