### PR TITLE
Share background image list

### DIFF
--- a/true-self-sim/front/src/constants/backgroundImages.ts
+++ b/true-self-sim/front/src/constants/backgroundImages.ts
@@ -1,0 +1,7 @@
+export const backgroundImgs = [
+    "mountain.jpg",
+    "loading-background1.png",
+    "loading-background2.png",
+    "loading-background3.png",
+    "loading-background4.png",
+];

--- a/true-self-sim/front/src/pages/PublicAdmin.tsx
+++ b/true-self-sim/front/src/pages/PublicAdmin.tsx
@@ -6,6 +6,7 @@ import {useNavigate} from "react-router-dom";
 import AuthContext from "../context/AuthContext.tsx";
 import useDeletePublicScene from "../hook/useDeletePublicScene.ts";
 import usePostPublicSceneBulk from "../hook/usePostPublicSceneBulk.ts";
+import { backgroundImgs } from "../constants/backgroundImages.ts";
 
 const PublicAdmin: React.FC = () => {
 
@@ -31,13 +32,6 @@ const PublicAdmin: React.FC = () => {
     const otherSceneAlreadyStart = data?.publicScenes?.some(scene => scene.start && scene.sceneId !== currentId);
 
     const [useCustomImg, setUseCustomImg] = useState(false);
-    const backgroundImgs = [
-        "mountain.jpg",
-        'loading-background1.png',
-        'loading-background2.png',
-        'loading-background3.png',
-        'loading-background4.png',
-    ]
 
     useEffect(() => {
         if (currentId === "") return;

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -22,6 +22,7 @@ import usePublicStory from "../hook/usePublicStory.ts";
 import usePostPublicSceneBulk from "../hook/usePostPublicSceneBulk.ts";
 import useDeletePublicScene from "../hook/useDeletePublicScene.ts";
 import { useNavigate } from 'react-router-dom';
+import { backgroundImgs } from "../constants/backgroundImages.ts";
 
 type Selection = {
     nodes: FlowNode[];
@@ -157,7 +158,20 @@ const PublicAdminGraph: React.FC = () => {
 
     const handleAddScene = () => {
         const newId = `s${idCounter.current++}`;
-        setNodes((nds) => nds.concat({ id: newId, type: 'editableNode', position: { x: 100, y: 100 }, data: { sceneId: newId, speaker: '', backgroundImage: '', text: '', start: false, end: false, onUpdate: handleNodeUpdate } }));
+        setNodes((nds) => nds.concat({
+            id: newId,
+            type: 'editableNode',
+            position: { x: 100, y: 100 },
+            data: {
+                sceneId: newId,
+                speaker: '',
+                backgroundImage: backgroundImgs[0],
+                text: '',
+                start: false,
+                end: false,
+                onUpdate: handleNodeUpdate
+            }
+        }));
     };
 
     // keep end flag in sync with outgoing edges and enforce single start node


### PR DESCRIPTION
## Summary
- centralize default background images
- use shared background list in public admin pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a499fa9848323beb368114918bdcf