### PR TITLE
Support parallel edges in admin graph

### DIFF
--- a/true-self-sim/front/src/component/CurvedEdge.tsx
+++ b/true-self-sim/front/src/component/CurvedEdge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BaseEdge, EdgeLabelRenderer, EdgeProps } from 'reactflow';
+import { BaseEdge, EdgeLabelRenderer, type EdgeProps } from 'reactflow';
 
 const OFFSET_DISTANCE = 40;
 

--- a/true-self-sim/front/src/component/CurvedEdge.tsx
+++ b/true-self-sim/front/src/component/CurvedEdge.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { BaseEdge, EdgeLabelRenderer, EdgeProps } from 'reactflow';
+
+const OFFSET_DISTANCE = 40;
+
+export default function CurvedEdge({ id, sourceX, sourceY, targetX, targetY, markerEnd, style, data }: EdgeProps) {
+  const index = data?.offset ?? 0;
+  const offset = index * OFFSET_DISTANCE;
+  const horizontal = Math.abs(sourceX - targetX) > Math.abs(sourceY - targetY);
+  const controlX = (sourceX + targetX) / 2 + (horizontal ? 0 : offset);
+  const controlY = (sourceY + targetY) / 2 + (horizontal ? offset : 0);
+
+  const path = `M${sourceX},${sourceY} Q${controlX},${controlY} ${targetX},${targetY}`;
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} markerEnd={markerEnd} style={style} />
+      {data?.label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${controlX}px, ${controlY}px)`,
+              pointerEvents: 'all',
+              fontSize: 12,
+            }}
+            className="nodrag nopan"
+          >
+            {data.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -3,7 +3,6 @@ import ReactFlow, {
     MiniMap,
     Controls,
     Background,
-    addEdge,
     MarkerType,
     ReactFlowProvider,
     useNodesState,
@@ -172,10 +171,21 @@ const PublicAdminGraph: React.FC = () => {
         setSelection({ nodes: [], edges: [] });
     }
 
+
     const onConnect = useCallback((connection: Connection) => {
-        const id = `e${Date.now()}`;
-        const newEdge = { ...connection, id, label: '', markerEnd: { type: MarkerType.ArrowClosed } };
-        setEdges((eds) => assignOffsets(addEdge(newEdge, eds)));
+        const newEdge: FlowEdge = {
+            id: `e${Date.now()}`,
+            source: connection.source!,
+            target: connection.target!,
+            sourceHandle: connection.sourceHandle,
+            targetHandle: connection.targetHandle,
+            type: 'default',
+            markerEnd: { type: MarkerType.ArrowClosed },
+        };
+        setEdges((eds) =>
+            // 기존 addEdge 대신, 배열에 직접 추가
+            assignOffsets([...eds, newEdge])
+        );
     }, [setEdges]);
 
     const onSelectionChange = useCallback((sel: Selection) => {
@@ -238,7 +248,7 @@ const PublicAdminGraph: React.FC = () => {
         setNodes((nds) =>
             nds.map((n) => ({
                 ...n,
-                data: { ...n.data, invalid: !!invalidNodes[n.id] },
+                data: { ...n.data, invalid: invalidNodes[n.id] ?? false },
             }))
         );
     }, [invalidNodes, setNodes]);

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -9,6 +9,7 @@ import ReactFlow, {
     useNodesState,
     useEdgesState,
     applyEdgeChanges,
+    ConnectionMode,
     type EdgeChange,
 } from 'reactflow';
 import type {
@@ -358,7 +359,7 @@ const PublicAdminGraph: React.FC = () => {
                 edges={edges}
                 nodeTypes={nodeTypes}
                 edgeTypes={edgeTypes}
-                connectionMode="loose"
+                connectionMode={ConnectionMode.Loose}
                 onConnect={onConnect}
                 onNodesChange={onNodesChange}
                 onEdgesChange={onEdgesChange}

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -8,8 +8,8 @@ import ReactFlow, {
     ReactFlowProvider,
     useNodesState,
     useEdgesState,
-    EdgeChange,
     applyEdgeChanges,
+    type EdgeChange,
 } from 'reactflow';
 import type {
     Node as FlowNode,


### PR DESCRIPTION
## Summary
- add a `CurvedEdge` component for drawing offset quadratic edges
- enable custom edge types in `PublicAdminGraph`
- compute offsets so parallel edges do not overlap
- generate unique edge ids when adding edges

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a695117148323b02ebf98ff1e7ebd