### PR TITLE
Fix edge rendering issues

### DIFF
--- a/true-self-sim/front/src/component/CurvedEdge.tsx
+++ b/true-self-sim/front/src/component/CurvedEdge.tsx
@@ -3,7 +3,7 @@ import { BaseEdge, EdgeLabelRenderer, type EdgeProps } from 'reactflow';
 
 const OFFSET_DISTANCE = 40;
 
-export default function CurvedEdge({ id, sourceX, sourceY, targetX, targetY, markerEnd, style, data }: EdgeProps) {
+export default function CurvedEdge({ id, sourceX, sourceY, targetX, targetY, markerEnd, style, label, data }: EdgeProps) {
   const index = data?.offset ?? 0;
   const offset = index * OFFSET_DISTANCE;
   const horizontal = Math.abs(sourceX - targetX) > Math.abs(sourceY - targetY);
@@ -15,7 +15,7 @@ export default function CurvedEdge({ id, sourceX, sourceY, targetX, targetY, mar
   return (
     <>
       <BaseEdge id={id} path={path} markerEnd={markerEnd} style={style} />
-      {data?.label && (
+      {(data?.label || label) && (
         <EdgeLabelRenderer>
           <div
             style={{
@@ -26,7 +26,7 @@ export default function CurvedEdge({ id, sourceX, sourceY, targetX, targetY, mar
             }}
             className="nodrag nopan"
           >
-            {data.label}
+            {data?.label ?? label}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -46,7 +46,11 @@ const assignOffsets = (eds: FlowEdge[]): FlowEdge[] => {
         const group = groups[`${e.source}-${e.target}`];
         const index = group.indexOf(e);
         const offsetIndex = index - (group.length - 1) / 2;
-        return { ...e, type: 'curved', data: { ...(e.data || {}), offset: offsetIndex } };
+        return {
+            ...e,
+            type: 'curved',
+            data: { ...(e.data || {}), label: e.label, offset: offsetIndex },
+        };
     });
 };
 
@@ -185,7 +189,13 @@ const PublicAdminGraph: React.FC = () => {
     const handleEdgeLabelSave = () => {
         if (selection.edges.length !== 1) return;
         const edgeId = selection.edges[0].id;
-        setEdges((eds) => eds.map((edge) => edge.id === edgeId ? { ...edge, label: edgeLabel } : edge));
+        setEdges((eds) =>
+            assignOffsets(
+                eds.map((edge) =>
+                    edge.id === edgeId ? { ...edge, label: edgeLabel } : edge
+                )
+            )
+        );
     };
 
     const handleAddScene = () => {
@@ -348,6 +358,7 @@ const PublicAdminGraph: React.FC = () => {
                 edges={edges}
                 nodeTypes={nodeTypes}
                 edgeTypes={edgeTypes}
+                connectionMode="loose"
                 onConnect={onConnect}
                 onNodesChange={onNodesChange}
                 onEdgesChange={onEdgesChange}


### PR DESCRIPTION
## Summary
- support `label` prop in `CurvedEdge` so edge text shows again
- preserve label in `assignOffsets` and apply it when editing labels
- enable `connectionMode="loose"` for ReactFlow to allow more than two connections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a719a6ffc8323bdaf76eb837a4095