### PR TITLE
Implement private story support

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/config/Security.java
+++ b/true-self-sim/back/src/main/java/com/self_true/config/Security.java
@@ -54,6 +54,7 @@ public class Security {
                                          * */
                                         "/admin/**"
                                 ).hasRole("ADMIN")
+                                .requestMatchers("/my/**").authenticated()
                                 .anyRequest().authenticated());
 
         return http.build();

--- a/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
@@ -1,0 +1,59 @@
+package com.self_true.controller;
+
+import com.self_true.model.dto.request.PrivateSceneRequest;
+import com.self_true.model.dto.response.PrivateStoryResponse;
+import com.self_true.model.dto.response.Response;
+import com.self_true.service.PrivateStoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/my")
+@Tag(name = "MyController", description = "사용자 개인 스토리 API")
+public class MyController {
+
+    private final PrivateStoryService privateStoryService;
+
+    public MyController(PrivateStoryService privateStoryService) {
+        this.privateStoryService = privateStoryService;
+    }
+
+    @Operation(summary = "내 장면 저장")
+    @PostMapping("/scene/{id}")
+    public ResponseEntity<Response> createOrUpdate(@PathVariable String id,
+                                                   @RequestBody PrivateSceneRequest request,
+                                                   @AuthenticationPrincipal String memberId) {
+        privateStoryService.createOrUpdate(request, id, memberId);
+        return ResponseEntity.ok(new Response(true, "장면 저장 완료"));
+    }
+
+    @Operation(summary = "내 장면 삭제")
+    @DeleteMapping("/scene/{id}")
+    public ResponseEntity<Response> delete(@PathVariable String id,
+                                           @AuthenticationPrincipal String memberId) {
+        privateStoryService.delete(id, memberId);
+        return ResponseEntity.ok(new Response(true, "장면 삭제 완료"));
+    }
+
+    @Operation(summary = "내 장면 전체 조회")
+    @GetMapping("/story")
+    public ResponseEntity<PrivateStoryResponse> getStory(@AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScenes(memberId));
+    }
+
+    @Operation(summary = "내 첫 장면 호출")
+    @GetMapping("/scene")
+    public ResponseEntity<?> getFirst(@AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getFirstScene(memberId));
+    }
+
+    @Operation(summary = "내 특정 장면 호출")
+    @GetMapping("/scene/{id}")
+    public ResponseEntity<?> getScene(@PathVariable String id, @AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, memberId));
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateChoiceRequest.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateChoiceRequest.java
@@ -1,0 +1,19 @@
+package com.self_true.model.dto.request;
+
+import com.self_true.model.entity.PrivateChoice;
+import lombok.Data;
+
+@Data
+public class PrivateChoiceRequest {
+    private String nextSceneId;
+    private String text;
+
+    public PrivateChoice toEntity(String privateSceneId, Long memberId) {
+        return PrivateChoice.builder()
+                .text(this.text)
+                .nextPrivateSceneId(this.nextSceneId)
+                .privateSceneId(privateSceneId)
+                .memberId(memberId)
+                .build();
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateSceneRequest.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateSceneRequest.java
@@ -1,0 +1,36 @@
+package com.self_true.model.dto.request;
+
+import com.self_true.model.entity.PrivateChoice;
+import com.self_true.model.entity.PrivateScene;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PrivateSceneRequest {
+    private String sceneId;
+    private String speaker;
+    private String backgroundImage;
+    private String text;
+    private boolean isStart = false;
+    private boolean isEnd = false;
+    private List<PrivateChoiceRequest> choiceRequests;
+
+    public PrivateScene toEntity(Long memberId) {
+        return PrivateScene.builder()
+                .privateSceneId(sceneId)
+                .speaker(speaker)
+                .backgroundImage(backgroundImage)
+                .text(text)
+                .isStart(isStart)
+                .isEnd(isEnd)
+                .memberId(memberId)
+                .build();
+    }
+
+    public List<PrivateChoice> toChoiceEntities(Long memberId) {
+        return choiceRequests.stream()
+                .map(cr -> cr.toEntity(sceneId, memberId))
+                .toList();
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/response/PrivateChoiceResponse.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/response/PrivateChoiceResponse.java
@@ -1,0 +1,16 @@
+package com.self_true.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrivateChoiceResponse {
+    private String text;
+    private String nextPrivateSceneId;
+    private String nextText;
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/response/PrivateSceneResponse.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/response/PrivateSceneResponse.java
@@ -1,0 +1,30 @@
+package com.self_true.model.dto.response;
+
+import com.self_true.model.entity.PrivateScene;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+public class PrivateSceneResponse {
+    private String sceneId;
+    private String speaker;
+    private String backgroundImage;
+    private String text;
+    private boolean isStart;
+    private boolean isEnd;
+    private List<PrivateChoiceResponse> texts;
+
+    public static PrivateSceneResponse fromEntity(PrivateScene entity) {
+        return PrivateSceneResponse.builder()
+                .sceneId(entity.getPrivateSceneId())
+                .speaker(entity.getSpeaker())
+                .backgroundImage(entity.getBackgroundImage())
+                .text(entity.getText())
+                .isStart(entity.getIsStart())
+                .isEnd(entity.getIsEnd())
+                .build();
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/response/PrivateStoryResponse.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/response/PrivateStoryResponse.java
@@ -1,0 +1,22 @@
+package com.self_true.model.dto.response;
+
+import com.self_true.model.entity.PrivateScene;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class PrivateStoryResponse extends Response {
+    List<PrivateSceneResponse> privateScenes;
+
+    public PrivateStoryResponse(List<PrivateSceneResponse> privateScenes) {
+        this.privateScenes = privateScenes;
+        setIsSuccess(true);
+    }
+
+    public static PrivateStoryResponse fromEntity(List<PrivateScene> scenes) {
+        return new PrivateStoryResponse(scenes.stream().map(PrivateSceneResponse::fromEntity).toList());
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateChoice.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateChoice.java
@@ -1,0 +1,24 @@
+package com.self_true.model.entity;
+
+import com.self_true.model.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Data
+@Entity
+@EqualsAndHashCode(callSuper = false)
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrivateChoice extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String text;
+    private String privateSceneId;
+    private String nextPrivateSceneId;
+
+    private Long memberId;
+}
+

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateLog.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateLog.java
@@ -1,0 +1,19 @@
+package com.self_true.model.entity;
+
+import com.self_true.model.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrivateLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+    private String privateSceneId;
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateScene.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateScene.java
@@ -1,0 +1,28 @@
+package com.self_true.model.entity;
+
+import com.self_true.model.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Data
+@Entity
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrivateScene extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String privateSceneId;
+
+    private String speaker;
+    private String backgroundImage;
+    private String text;
+    private Boolean isStart;
+    private Boolean isEnd;
+
+    private Long memberId;
+}
+

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateChoiceRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateChoiceRepository.java
@@ -1,0 +1,11 @@
+package com.self_true.repository;
+
+import com.self_true.model.entity.PrivateChoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PrivateChoiceRepository extends JpaRepository<PrivateChoice, Long> {
+    List<PrivateChoice> findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(Long memberId, String privateSceneId);
+    List<PrivateChoice> findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(Long memberId, List<String> privateSceneIds);
+}

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateLogRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateLogRepository.java
@@ -1,0 +1,7 @@
+package com.self_true.repository;
+
+import com.self_true.model.entity.PrivateLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PrivateLogRepository extends JpaRepository<PrivateLog, Long> {
+}

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateSceneRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateSceneRepository.java
@@ -1,0 +1,17 @@
+package com.self_true.repository;
+
+import com.self_true.model.entity.PrivateScene;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PrivateSceneRepository extends JpaRepository<PrivateScene, Long> {
+    List<PrivateScene> findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
+
+    Optional<PrivateScene> findFirstByMemberIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
+
+    Optional<PrivateScene> findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(Long memberId, String privateSceneId);
+
+    List<PrivateScene> findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(Long memberId, List<String> privateSceneIds);
+}

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -1,0 +1,167 @@
+package com.self_true.service;
+
+import com.self_true.exception.NotFoundSceneException;
+import com.self_true.model.dto.request.PrivateSceneRequest;
+import com.self_true.model.dto.response.PrivateChoiceResponse;
+import com.self_true.model.dto.response.PrivateSceneResponse;
+import com.self_true.model.dto.response.PrivateStoryResponse;
+import com.self_true.model.entity.Member;
+import com.self_true.model.entity.PrivateChoice;
+import com.self_true.model.entity.PrivateLog;
+import com.self_true.model.entity.PrivateScene;
+import com.self_true.repository.PrivateChoiceRepository;
+import com.self_true.repository.PrivateLogRepository;
+import com.self_true.repository.PrivateSceneRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class PrivateStoryService {
+    private final PrivateSceneRepository sceneRepository;
+    private final PrivateChoiceRepository choiceRepository;
+    private final PrivateLogRepository logRepository;
+    private final MemberService memberService;
+
+    public PrivateStoryService(
+            PrivateSceneRepository sceneRepository,
+            PrivateChoiceRepository choiceRepository,
+            PrivateLogRepository logRepository,
+            MemberService memberService) {
+        this.sceneRepository = sceneRepository;
+        this.choiceRepository = choiceRepository;
+        this.logRepository = logRepository;
+        this.memberService = memberService;
+    }
+
+    private void saveSceneLog(String memberId, PrivateSceneResponse response) {
+        memberService.findById(memberId)
+                .map(Member::getId)
+                .map(userId -> PrivateLog.builder()
+                        .privateSceneId(response.getSceneId())
+                        .memberId(userId)
+                        .build())
+                .ifPresent(logRepository::save);
+    }
+
+    public PrivateSceneResponse getFirstScene(String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElse(null);
+        PrivateSceneResponse response = Optional.ofNullable(userId)
+                .flatMap(id -> sceneRepository.findFirstByMemberIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(id))
+                .map(PrivateSceneResponse::fromEntity)
+                .orElse(PrivateSceneResponse.builder()
+                        .sceneId("")
+                        .speaker("")
+                        .backgroundImage("loading-background1.png")
+                        .text("첫 번째 화면이 없습니다.")
+                        .isStart(false)
+                        .isEnd(false)
+                        .build());
+        response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), userId));
+        if (userId != null) saveSceneLog(memberId, response);
+        return response;
+    }
+
+    public PrivateSceneResponse getPrivateScene(String id, String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        PrivateSceneResponse response = sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
+                .map(PrivateSceneResponse::fromEntity)
+                .orElseThrow(() -> new NotFoundSceneException("not found scene id: " + id));
+        response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), userId));
+        saveSceneLog(memberId, response);
+        return response;
+    }
+
+    private List<PrivateChoiceResponse> getChoiceResponsesBySceneId(String sceneId, Long memberId) {
+        if (memberId == null) return List.of();
+        return choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(memberId, sceneId).stream()
+                .map(pc -> PrivateChoiceResponse.builder()
+                        .text(pc.getText())
+                        .nextPrivateSceneId(pc.getNextPrivateSceneId())
+                        .build())
+                .toList();
+    }
+
+    public void saveAll(List<PrivateSceneRequest> requests, String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        List<String> sceneIds = requests.stream().map(PrivateSceneRequest::getSceneId).toList();
+        choiceRepository.findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(userId, sceneIds)
+                .forEach(cr -> cr.setDeletedAt(LocalDateTime.now()));
+        List<PrivateScene> existing = sceneRepository.findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(userId, sceneIds);
+        Map<String, PrivateScene> existingMap = existing.stream()
+                .collect(Collectors.toMap(PrivateScene::getPrivateSceneId, Function.identity()));
+        List<PrivateScene> scenesToSave = requests.stream().map(req -> {
+            PrivateScene scene = existingMap.getOrDefault(req.getSceneId(),
+                    PrivateScene.builder().privateSceneId(req.getSceneId()).memberId(userId).build());
+            scene.setSpeaker(req.getSpeaker());
+            scene.setBackgroundImage(req.getBackgroundImage());
+            scene.setText(req.getText());
+            scene.setIsStart(req.isStart());
+            scene.setIsEnd(req.isEnd());
+            return scene;
+        }).toList();
+        sceneRepository.saveAll(scenesToSave);
+        List<PrivateChoice> choices = requests.stream()
+                .flatMap(r -> r.getChoiceRequests().stream().map(cr -> cr.toEntity(r.getSceneId(), userId)))
+                .toList();
+        choiceRepository.saveAll(choices);
+    }
+
+    public void createOrUpdate(PrivateSceneRequest request, String id, String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        Optional<PrivateScene> opt = sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id);
+        if (opt.isPresent()) {
+            PrivateScene entity = opt.get();
+            entity.setSpeaker(request.getSpeaker());
+            entity.setBackgroundImage(request.getBackgroundImage());
+            entity.setText(request.getText());
+            entity.setIsStart(request.isStart());
+            entity.setIsEnd(request.isEnd());
+        } else {
+            PrivateScene entity = request.toEntity(userId);
+            entity.setPrivateSceneId(id);
+            sceneRepository.save(entity);
+        }
+        choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
+                .forEach(cr -> cr.setDeletedAt(LocalDateTime.now()));
+        List<PrivateChoice> choices = request.getChoiceRequests().stream()
+                .map(cr -> {
+                    PrivateChoice entity = cr.toEntity(request.getSceneId(), userId);
+                    entity.setPrivateSceneId(id);
+                    return entity;
+                }).toList();
+        choiceRepository.saveAll(choices);
+    }
+
+    public void delete(String id, String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
+                .ifPresent(scene -> {
+                    choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, scene.getPrivateSceneId())
+                            .forEach(cr -> cr.setDeletedAt(LocalDateTime.now()));
+                    sceneRepository.save(scene);
+                    scene.setDeletedAt(LocalDateTime.now());
+                });
+    }
+
+    @Transactional(readOnly = true)
+    public PrivateStoryResponse getPrivateScenes(String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        PrivateStoryResponse resp = PrivateStoryResponse.fromEntity(sceneRepository.findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId));
+        resp.getPrivateScenes().forEach(scene -> {
+            List<PrivateChoice> choices = choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, scene.getSceneId());
+            List<PrivateChoiceResponse> list = choices.stream()
+                    .map(c -> PrivateChoiceResponse.builder().text(c.getText()).nextPrivateSceneId(c.getNextPrivateSceneId()).build())
+                    .toList();
+            scene.setTexts(list);
+        });
+        return resp;
+    }
+}

--- a/true-self-sim/back/src/test/java/com/self_true/controller/MyControllerTest.java
+++ b/true-self-sim/back/src/test/java/com/self_true/controller/MyControllerTest.java
@@ -1,0 +1,44 @@
+package com.self_true.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.self_true.model.dto.request.PrivateSceneRequest;
+import com.self_true.service.PrivateStoryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MyController.class)
+class MyControllerTest {
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    PrivateStoryService privateStoryService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser
+    void createOrUpdate() throws Exception {
+        PrivateSceneRequest req = new PrivateSceneRequest();
+        req.setSceneId("a");
+        req.setSpeaker("sp");
+        req.setBackgroundImage("bg");
+        req.setText("t");
+        req.setChoiceRequests(List.of());
+        mvc.perform(post("/my/scene/a")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+}

--- a/true-self-sim/back/src/test/java/com/self_true/repository/PrivateSceneRepositoryTest.java
+++ b/true-self-sim/back/src/test/java/com/self_true/repository/PrivateSceneRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.self_true.repository;
+
+import com.self_true.model.entity.PrivateScene;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class PrivateSceneRepositoryTest {
+    @Autowired
+    PrivateSceneRepository privateSceneRepository;
+
+    @Test
+    void saveAndFind() {
+        PrivateScene scene = PrivateScene.builder()
+                .privateSceneId("s1")
+                .speaker("sp")
+                .backgroundImage("bg")
+                .text("txt")
+                .isStart(true)
+                .isEnd(false)
+                .memberId(1L)
+                .build();
+        privateSceneRepository.save(scene);
+        assertThat(privateSceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(1L, "s1")).isPresent();
+    }
+}

--- a/true-self-sim/front/src/App.tsx
+++ b/true-self-sim/front/src/App.tsx
@@ -10,6 +10,7 @@ function App() {
     const PublicGame = lazy(() => import("./pages/PublicGame.tsx"))
     const PublicAdmin = lazy(() => import("./pages/PublicAdmin.tsx"))
     const PublicAdminGraph = lazy(() => import("./pages/PublicAdminGraph.tsx"))
+    const PrivateAdmin = lazy(() => import("./pages/PrivateAdmin.tsx"))
 
   return (
       <AuthProvider>
@@ -21,7 +22,8 @@ function App() {
                           <Route path={"/login"} element={<Login/>}/>
                           <Route path={"/register"} element={<Register/>}/>
                           <Route path={"/admin/public"} element={<PublicAdmin/>}/>
-                          <Route path={"/admin/public/graph"} element={<PublicAdminGraph/>}/>
+                        <Route path={"/admin/public/graph"} element={<PublicAdminGraph/>}/>
+                        <Route path={"/my"} element={<PrivateAdmin/>}/>
                       </Routes>
                   </Suspense>
               </ErrorBoundary>

--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -1,4 +1,4 @@
-import type {PublicSceneRequest, PrivateStory} from "../types.ts";
+import type {PrivateSceneRequest, PrivateStory} from "../types.ts";
 import api from "./api.ts";
 
 export const getMyStory = async (): Promise<PrivateStory> => {
@@ -6,7 +6,7 @@ export const getMyStory = async (): Promise<PrivateStory> => {
     return res.data;
 }
 
-export const postMyScene = async (data: PublicSceneRequest) => {
+export const postMyScene = async (data: PrivateSceneRequest) => {
     const res = await api.post(`/my/scene/${data.sceneId}`, data);
     return res.data;
 }

--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -1,0 +1,17 @@
+import type {PublicSceneRequest, PublicStory} from "../types.ts";
+import api from "./api.ts";
+
+export const getMyStory = async (): Promise<PublicStory> => {
+    const res = await api.get<PublicStory>("/my/story");
+    return res.data;
+}
+
+export const postMyScene = async (data: PublicSceneRequest) => {
+    const res = await api.post(`/my/scene/${data.sceneId}`, data);
+    return res.data;
+}
+
+export const deleteMyScene = async (id: string) => {
+    const res = await api.delete(`/my/scene/${id}`);
+    return res.data;
+}

--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -1,8 +1,8 @@
-import type {PublicSceneRequest, PublicStory} from "../types.ts";
+import type {PublicSceneRequest, PrivateStory} from "../types.ts";
 import api from "./api.ts";
 
-export const getMyStory = async (): Promise<PublicStory> => {
-    const res = await api.get<PublicStory>("/my/story");
+export const getMyStory = async (): Promise<PrivateStory> => {
+    const res = await api.get<PrivateStory>("/my/story");
     return res.data;
 }
 

--- a/true-self-sim/front/src/hook/useDeleteMyScene.ts
+++ b/true-self-sim/front/src/hook/useDeleteMyScene.ts
@@ -1,0 +1,10 @@
+import {useMutation} from "@tanstack/react-query";
+import {deleteMyScene} from "../api/myScene.ts";
+
+const useDeleteMyScene = () => {
+    return useMutation({
+        mutationFn: (id: string) => deleteMyScene(id)
+    })
+}
+
+export default useDeleteMyScene;

--- a/true-self-sim/front/src/hook/useMyStory.ts
+++ b/true-self-sim/front/src/hook/useMyStory.ts
@@ -1,0 +1,11 @@
+import {useSuspenseQuery} from "@tanstack/react-query";
+import {getMyStory} from "../api/myScene.ts";
+
+const useMyStory = () => {
+    return useSuspenseQuery({
+        queryKey: ['myStory'],
+        queryFn: getMyStory,
+    });
+}
+
+export default useMyStory;

--- a/true-self-sim/front/src/hook/useMyStory.ts
+++ b/true-self-sim/front/src/hook/useMyStory.ts
@@ -1,8 +1,9 @@
 import {useSuspenseQuery} from "@tanstack/react-query";
 import {getMyStory} from "../api/myScene.ts";
+import type {PrivateStory} from "../types.ts";
 
 const useMyStory = () => {
-    return useSuspenseQuery({
+    return useSuspenseQuery<PrivateStory>({
         queryKey: ['myStory'],
         queryFn: getMyStory,
     });

--- a/true-self-sim/front/src/hook/usePostMyScene.ts
+++ b/true-self-sim/front/src/hook/usePostMyScene.ts
@@ -1,10 +1,10 @@
 import {useMutation} from "@tanstack/react-query";
-import type {PublicSceneRequest} from "../types.ts";
+import type {PrivateSceneRequest} from "../types.ts";
 import {postMyScene} from "../api/myScene.ts";
 
 const usePostMyScene = () => {
     return useMutation({
-        mutationFn: (data: PublicSceneRequest) => postMyScene(data)
+        mutationFn: (data: PrivateSceneRequest) => postMyScene(data)
     });
 }
 

--- a/true-self-sim/front/src/hook/usePostMyScene.ts
+++ b/true-self-sim/front/src/hook/usePostMyScene.ts
@@ -1,0 +1,11 @@
+import {useMutation} from "@tanstack/react-query";
+import type {PublicSceneRequest} from "../types.ts";
+import {postMyScene} from "../api/myScene.ts";
+
+const usePostMyScene = () => {
+    return useMutation({
+        mutationFn: (data: PublicSceneRequest) => postMyScene(data)
+    });
+}
+
+export default usePostMyScene;

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -28,7 +28,7 @@ const PrivateAdmin: React.FC = () => {
 
     useEffect(() => {
         if (!currentId) return;
-        const sc = data?.publicScenes.find(s => s.sceneId === currentId);
+        const sc = data?.privateScenes.find(s => s.sceneId === currentId);
         if (sc) {
             setRequest({
                 sceneId: sc.sceneId,
@@ -37,7 +37,7 @@ const PrivateAdmin: React.FC = () => {
                 text: sc.text,
                 choiceRequests: Array.isArray(sc.texts)
                     ? sc.texts.map(t => ({
-                        nextSceneId: t.nextPublicSceneId,
+                        nextSceneId: t.nextPrivateSceneId,
                         text: t.text
                     }))
                     : [],
@@ -77,7 +77,7 @@ const PrivateAdmin: React.FC = () => {
                         로그아웃
                     </button>
                     <ul className="space-y-2">
-                        {data?.publicScenes?.map((sc) => (
+                        {data?.privateScenes?.map((sc) => (
                             <li key={sc.sceneId}>
                                 <button
                                     onClick={() => setCurrentId(sc.sceneId)}

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -57,26 +57,85 @@ const PrivateAdmin: React.FC = () => {
     };
 
     return (
-        <div className="p-4">
-            <button onClick={() => navigate("/")}>돌아가기</button>
-            <button onClick={async () => {await logout();await refreshUser();navigate("/")}}>로그아웃</button>
-            <div className="flex">
-                <aside className="w-1/4">
-                    <ul>
-                        {data?.publicScenes?.map(sc => (
+        <div className="min-h-screen bg-gray-50 p-4 sm:p-6">
+            <div className="max-w-5xl mx-auto flex flex-col md:flex-row gap-6">
+                <aside className="w-full md:w-1/4 border-b md:border-b-0 md:border-r bg-gray-100 p-4 rounded-md md:rounded-none overflow-auto">
+                    <button
+                        className="mb-2 w-full py-2 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600 transition"
+                        onClick={() => navigate('/')}
+                    >
+                        돌아가기
+                    </button>
+                    <button
+                        className="mb-2 w-full py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition"
+                        onClick={async () => {
+                            await logout();
+                            await refreshUser();
+                            navigate('/');
+                        }}
+                    >
+                        로그아웃
+                    </button>
+                    <ul className="space-y-2">
+                        {data?.publicScenes?.map((sc) => (
                             <li key={sc.sceneId}>
-                                <button onClick={() => setCurrentId(sc.sceneId)}>{sc.sceneId}</button>
+                                <button
+                                    onClick={() => setCurrentId(sc.sceneId)}
+                                    className={`w-full text-left px-2 py-1 rounded ${sc.sceneId === currentId ? 'bg-indigo-200 font-semibold' : 'hover:bg-gray-200'}`}
+                                >
+                                    <span className="text-sm text-gray-700 font-mono">[{sc.sceneId}]</span> {sc.text}
+                                </button>
                             </li>
                         ))}
                     </ul>
                 </aside>
-                <section className="flex-1">
-                    <input value={request.sceneId} onChange={e => setRequest(r=>({...r,sceneId:e.target.value}))} />
-                    <input value={request.speaker} onChange={e=>setRequest(r=>({...r,speaker:e.target.value}))}/>
-                    <input value={request.backgroundImage} onChange={e=>setRequest(r=>({...r,backgroundImage:e.target.value}))}/>
-                    <textarea value={request.text} onChange={e=>setRequest(r=>({...r,text:e.target.value}))}/>
-                    <button onClick={handleSave}>저장</button>
-                    {currentId && <button onClick={handleDelete}>삭제</button>}
+                <section className="w-full md:flex-1 bg-white p-4 rounded-md shadow flex flex-col space-y-4 overflow-auto">
+                    <div>
+                        <label className="block text-sm font-medium">Scene ID</label>
+                        <input
+                            type="text"
+                            className="mt-1 w-full border rounded p-2"
+                            value={request.sceneId}
+                            onChange={(e) => setRequest((r) => ({ ...r, sceneId: e.target.value }))}
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium">Speaker</label>
+                        <input
+                            type="text"
+                            className="mt-1 w-full border rounded p-2"
+                            value={request.speaker}
+                            onChange={(e) => setRequest((r) => ({ ...r, speaker: e.target.value }))}
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium">Background Image</label>
+                        <input
+                            type="text"
+                            className="mt-1 w-full border rounded p-2"
+                            value={request.backgroundImage}
+                            onChange={(e) => setRequest((r) => ({ ...r, backgroundImage: e.target.value }))}
+                            placeholder="https://example.com/bg.jpg"
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium">Text</label>
+                        <textarea
+                            className="mt-1 w-full border rounded p-2 h-32"
+                            value={request.text}
+                            onChange={(e) => setRequest((r) => ({ ...r, text: e.target.value }))}
+                        />
+                    </div>
+                    <div className="flex space-x-2">
+                        <button className="px-4 py-2 bg-blue-600 text-white rounded-lg" onClick={handleSave}>
+                            저장
+                        </button>
+                        {currentId && (
+                            <button className="px-4 py-2 bg-red-600 text-white rounded-lg" onClick={handleDelete}>
+                                삭제
+                            </button>
+                        )}
+                    </div>
                 </section>
             </div>
         </div>

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -35,7 +35,12 @@ const PrivateAdmin: React.FC = () => {
                 speaker: sc.speaker,
                 backgroundImage: sc.backgroundImage,
                 text: sc.text,
-                choiceRequests: sc.texts.map(t => ({nextSceneId: t.nextPublicSceneId, text: t.text})),
+                choiceRequests: Array.isArray(sc.texts)
+                    ? sc.texts.map(t => ({
+                        nextSceneId: t.nextPublicSceneId,
+                        text: t.text
+                    }))
+                    : [],
                 start: sc.start,
                 end: sc.end,
             });
@@ -58,7 +63,7 @@ const PrivateAdmin: React.FC = () => {
             <div className="flex">
                 <aside className="w-1/4">
                     <ul>
-                        {data?.publicScenes.map(sc => (
+                        {data?.publicScenes?.map(sc => (
                             <li key={sc.sceneId}>
                                 <button onClick={() => setCurrentId(sc.sceneId)}>{sc.sceneId}</button>
                             </li>

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -2,9 +2,10 @@ import useMyStory from "../hook/useMyStory.ts";
 import usePostMyScene from "../hook/usePostMyScene.ts";
 import useDeleteMyScene from "../hook/useDeleteMyScene.ts";
 import {useContext, useEffect, useState} from "react";
-import type {PublicSceneRequest} from "../types.ts";
+import type {PrivateSceneRequest} from "../types.ts";
 import {useNavigate} from "react-router-dom";
 import AuthContext from "../context/AuthContext.tsx";
+import { backgroundImgs } from "../constants/backgroundImages.ts";
 
 const PrivateAdmin: React.FC = () => {
     const navigate = useNavigate();
@@ -16,7 +17,7 @@ const PrivateAdmin: React.FC = () => {
     if (error) navigate("/login");
 
     const [currentId, setCurrentId] = useState("");
-    const [request, setRequest] = useState<PublicSceneRequest>({
+    const [request, setRequest] = useState<PrivateSceneRequest>({
         sceneId: "",
         speaker: "",
         backgroundImage: "",
@@ -25,6 +26,32 @@ const PrivateAdmin: React.FC = () => {
         start: false,
         end: false,
     });
+    const [useCustomImg, setUseCustomImg] = useState(false);
+
+    const otherSceneAlreadyStart = data?.privateScenes?.some(
+        scene => scene.start && scene.sceneId !== currentId
+    );
+
+    const createNew = () => {
+        setCurrentId("");
+        setRequest({
+            sceneId: "",
+            speaker: "",
+            backgroundImage: "",
+            text: "",
+            choiceRequests: [],
+            start: false,
+            end: false,
+        });
+        setUseCustomImg(false);
+    };
+
+    const addChoice = () => {
+        setRequest(r => ({
+            ...r,
+            choiceRequests: [...r.choiceRequests, { text: "", nextSceneId: null }]
+        }));
+    };
 
     useEffect(() => {
         if (!currentId) return;
@@ -44,6 +71,7 @@ const PrivateAdmin: React.FC = () => {
                 start: sc.start,
                 end: sc.end,
             });
+            setUseCustomImg(!backgroundImgs.includes(sc.backgroundImage));
         }
     }, [currentId, data]);
 
@@ -76,6 +104,12 @@ const PrivateAdmin: React.FC = () => {
                     >
                         로그아웃
                     </button>
+                    <button
+                        className="mb-2 w-full py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition"
+                        onClick={createNew}
+                    >
+                        + 새 장면
+                    </button>
                     <ul className="space-y-2">
                         {data?.privateScenes?.map((sc) => (
                             <li key={sc.sceneId}>
@@ -96,45 +130,164 @@ const PrivateAdmin: React.FC = () => {
                             type="text"
                             className="mt-1 w-full border rounded p-2"
                             value={request.sceneId}
-                            onChange={(e) => setRequest((r) => ({ ...r, sceneId: e.target.value }))}
+                            onChange={(e) => setRequest(r => ({ ...r, sceneId: e.target.value }))}
+                            placeholder="예: s01"
                         />
                     </div>
-                    <div>
-                        <label className="block text-sm font-medium">Speaker</label>
-                        <input
-                            type="text"
-                            className="mt-1 w-full border rounded p-2"
-                            value={request.speaker}
-                            onChange={(e) => setRequest((r) => ({ ...r, speaker: e.target.value }))}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium">Background Image</label>
-                        <input
-                            type="text"
-                            className="mt-1 w-full border rounded p-2"
-                            value={request.backgroundImage}
-                            onChange={(e) => setRequest((r) => ({ ...r, backgroundImage: e.target.value }))}
-                            placeholder="https://example.com/bg.jpg"
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium">Text</label>
+
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium">text</label>
                         <textarea
                             className="mt-1 w-full border rounded p-2 h-32"
+                            placeholder="장면 내용을 입력하세요..."
                             value={request.text}
-                            onChange={(e) => setRequest((r) => ({ ...r, text: e.target.value }))}
+                            onChange={(e) => setRequest(r => ({ ...r, text: e.target.value }))}
                         />
                     </div>
-                    <div className="flex space-x-2">
-                        <button className="px-4 py-2 bg-blue-600 text-white rounded-lg" onClick={handleSave}>
+
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+                        <div>
+                            <label className="block text-sm font-medium">화자</label>
+                            <input
+                                type="text"
+                                className="mt-1 w-full border rounded p-2"
+                                value={request.speaker}
+                                onChange={(e) => setRequest(r => ({ ...r, speaker: e.target.value }))}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-1">배경이미지</label>
+                            <label className="inline-flex items-center mb-2 space-x-2">
+                                <input
+                                    type="checkbox"
+                                    checked={useCustomImg}
+                                    onChange={(e) => setUseCustomImg(e.target.checked)}
+                                />
+                                <span>직접 URL 입력</span>
+                            </label>
+                            <div className="w-full">
+                                {useCustomImg ? (
+                                    <input
+                                        type="text"
+                                        className="w-full border rounded p-2"
+                                        value={request.backgroundImage}
+                                        onChange={(e) => setRequest(r => ({ ...r, backgroundImage: e.target.value }))}
+                                        placeholder="https://example.com/bg.jpg"
+                                    />
+                                ) : (
+                                    <select
+                                        className="w-full border rounded p-2"
+                                        value={request.backgroundImage}
+                                        onChange={(e) => setRequest(r => ({ ...r, backgroundImage: e.target.value }))}
+                                    >
+                                        <option value="">배경 이미지 선택</option>
+                                        {backgroundImgs.map((img, index) => (
+                                            <option key={index} value={img}>{img}</option>
+                                        ))}
+                                    </select>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mb-4">
+                        <div className="flex justify-between items-center mb-2">
+                            <label className="text-sm font-medium">Choice</label>
+                            {data?.privateScenes?.length > 0 && (
+                                <button className="text-sm text-green-600" onClick={addChoice}>+ 추가</button>
+                            )}
+                        </div>
+                        {request.choiceRequests.length === 0 && (
+                            <p className="text-sm text-gray-400">선택지를 추가하려면 "+ 추가" 버튼을 누르세요.</p>
+                        )}
+                        {request.choiceRequests.map((choice, index) => (
+                            <div className="space-y-2" key={index}>
+                                <div className="flex flex-col sm:flex-row sm:space-x-2 space-y-2 sm:space-y-0">
+                                    <input
+                                        type="text"
+                                        placeholder="답변 텍스트"
+                                        className="border rounded p-1 flex-1"
+                                        value={choice.text}
+                                        onChange={(e) =>
+                                            setRequest(r => ({
+                                                ...r,
+                                                choiceRequests: r.choiceRequests.map((c, i) => i === index ? { ...c, text: e.target.value } : c)
+                                            }))
+                                        }
+                                    />
+                                    <select
+                                        className="border rounded p-1 flex-1"
+                                        value={choice.nextSceneId ?? ''}
+                                        onChange={(e) =>
+                                            setRequest(r => ({
+                                                ...r,
+                                                choiceRequests: r.choiceRequests.map((c, i) => i === index ? { ...c, nextSceneId: e.target.value } : c)
+                                            }))
+                                        }
+                                    >
+                                        <option value="" disabled>다음 장면 선택</option>
+                                        {data?.privateScenes?.filter(scene => scene.sceneId !== currentId)
+                                            .map(scene => (
+                                                <option key={scene.sceneId} value={scene.sceneId}>
+                                                    [{scene.sceneId}] {scene.text.length > 20 ? scene.text.slice(0, 20) + '...' : scene.text}
+                                                </option>
+                                            ))}
+                                    </select>
+                                    <button
+                                        className="text-red-600 self-center"
+                                        onClick={() => setRequest(r => ({
+                                            ...r,
+                                            choiceRequests: r.choiceRequests.filter((_, i) => i !== index)
+                                        }))}
+                                    >
+                                        x
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row sm:space-x-4 mb-4">
+                        {otherSceneAlreadyStart && !request.start && (
+                            <p className="text-xs text-gray-500 ml-6 mt-1">
+                                시작 장면은 하나만 지정할 수 있습니다.
+                            </p>
+                        )}
+                        <label className={`inline-flex items-center space-x-2 ${otherSceneAlreadyStart ? 'opacity-50 pointer-events-none' : ''}`}>
+                            <input
+                                type="checkbox"
+                                className="form-checkbox"
+                                checked={request.start}
+                                onChange={(e) => setRequest(r => ({ ...r, start: e.target.checked }))}
+                            />
+                            <span>Start Scene</span>
+                        </label>
+                        <label className="inline-flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                className="form-checkbox"
+                                checked={request.end}
+                                onChange={(e) => setRequest(r => ({ ...r, end: e.target.checked }))}
+                            />
+                            <span>End Scene</span>
+                        </label>
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row sm:space-x-2 space-y-2 sm:space-y-0">
+                        <button className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-lg" onClick={handleSave}>
                             저장
                         </button>
                         {currentId && (
-                            <button className="px-4 py-2 bg-red-600 text-white rounded-lg" onClick={handleDelete}>
+                            <button className="w-full sm:w-auto px-4 py-2 bg-red-600 text-white rounded-lg" onClick={handleDelete}>
                                 삭제
                             </button>
                         )}
+                        <button
+                            className="w-full sm:w-auto px-4 py-2 bg-gray-400 text-white rounded-lg"
+                            onClick={() => setRequest({ sceneId: '', speaker: '', backgroundImage: '', text: '', choiceRequests: [], start: false, end: false })}
+                        >
+                            입력 초기화
+                        </button>
                     </div>
                 </section>
             </div>

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -1,0 +1,81 @@
+import useMyStory from "../hook/useMyStory.ts";
+import usePostMyScene from "../hook/usePostMyScene.ts";
+import useDeleteMyScene from "../hook/useDeleteMyScene.ts";
+import {useContext, useEffect, useState} from "react";
+import type {PublicSceneRequest} from "../types.ts";
+import {useNavigate} from "react-router-dom";
+import AuthContext from "../context/AuthContext.tsx";
+
+const PrivateAdmin: React.FC = () => {
+    const navigate = useNavigate();
+    const {data, error} = useMyStory();
+    const {mutate: saveScene} = usePostMyScene();
+    const {mutate: deleteScene} = useDeleteMyScene();
+    const {refreshUser, logout} = useContext(AuthContext);
+
+    if (error) navigate("/login");
+
+    const [currentId, setCurrentId] = useState("");
+    const [request, setRequest] = useState<PublicSceneRequest>({
+        sceneId: "",
+        speaker: "",
+        backgroundImage: "",
+        text: "",
+        choiceRequests: [],
+        start: false,
+        end: false,
+    });
+
+    useEffect(() => {
+        if (!currentId) return;
+        const sc = data?.publicScenes.find(s => s.sceneId === currentId);
+        if (sc) {
+            setRequest({
+                sceneId: sc.sceneId,
+                speaker: sc.speaker,
+                backgroundImage: sc.backgroundImage,
+                text: sc.text,
+                choiceRequests: sc.texts.map(t => ({nextSceneId: t.nextPublicSceneId, text: t.text})),
+                start: sc.start,
+                end: sc.end,
+            });
+        }
+    }, [currentId, data]);
+
+    const handleSave = () => {
+        saveScene(request, {onSuccess: () => window.location.reload()});
+    };
+
+    const handleDelete = () => {
+        if (!currentId) return;
+        deleteScene(currentId, {onSuccess: () => window.location.reload()});
+    };
+
+    return (
+        <div className="p-4">
+            <button onClick={() => navigate("/")}>돌아가기</button>
+            <button onClick={async () => {await logout();await refreshUser();navigate("/")}}>로그아웃</button>
+            <div className="flex">
+                <aside className="w-1/4">
+                    <ul>
+                        {data?.publicScenes.map(sc => (
+                            <li key={sc.sceneId}>
+                                <button onClick={() => setCurrentId(sc.sceneId)}>{sc.sceneId}</button>
+                            </li>
+                        ))}
+                    </ul>
+                </aside>
+                <section className="flex-1">
+                    <input value={request.sceneId} onChange={e => setRequest(r=>({...r,sceneId:e.target.value}))} />
+                    <input value={request.speaker} onChange={e=>setRequest(r=>({...r,speaker:e.target.value}))}/>
+                    <input value={request.backgroundImage} onChange={e=>setRequest(r=>({...r,backgroundImage:e.target.value}))}/>
+                    <textarea value={request.text} onChange={e=>setRequest(r=>({...r,text:e.target.value}))}/>
+                    <button onClick={handleSave}>저장</button>
+                    {currentId && <button onClick={handleDelete}>삭제</button>}
+                </section>
+            </div>
+        </div>
+    );
+};
+
+export default PrivateAdmin;

--- a/true-self-sim/front/src/types.ts
+++ b/true-self-sim/front/src/types.ts
@@ -84,3 +84,18 @@ export interface PrivateStory {
     message: string;
     privateScenes: PrivateScene[];
 }
+
+export interface PrivateChoiceRequest {
+    nextSceneId: string | null;
+    text: string;
+}
+
+export interface PrivateSceneRequest {
+    sceneId?: string;
+    speaker: string;
+    backgroundImage: string;
+    text: string;
+    choiceRequests: PrivateChoiceRequest[];
+    start: boolean;
+    end: boolean;
+}

--- a/true-self-sim/front/src/types.ts
+++ b/true-self-sim/front/src/types.ts
@@ -62,3 +62,25 @@ export interface RegisterRequest {
     phoneNumber: string;
     email: string;
 }
+
+export interface PrivateChoice {
+    text: string;
+    nextPrivateSceneId: string;
+    nextText: string;
+}
+
+export interface PrivateScene {
+    sceneId: string;
+    speaker: string;
+    backgroundImage: string;
+    text: string;
+    texts: PrivateChoice[];
+    start: boolean;
+    end: boolean;
+}
+
+export interface PrivateStory {
+    isSuccess: boolean;
+    message: string;
+    privateScenes: PrivateScene[];
+}


### PR DESCRIPTION
## Summary
- add private story JPA entities and repositories
- implement PrivateStoryService and controller
- expose `/my/**` endpoints and extend security
- add React hooks and page to edit private scenes
- add simple JPA and controller tests

## Testing
- `./gradlew test` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685ce2433bc88323b99ffb4650796add