### PR TITLE
Add private story types

### DIFF
--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -1,8 +1,8 @@
-import type {PublicSceneRequest, PublicStory} from "../types.ts";
+import type {PublicSceneRequest, PrivateStory} from "../types.ts";
 import api from "./api.ts";
 
-export const getMyStory = async (): Promise<PublicStory> => {
-    const res = await api.get<PublicStory>("/my/story");
+export const getMyStory = async (): Promise<PrivateStory> => {
+    const res = await api.get<PrivateStory>("/my/story");
     return res.data;
 }
 

--- a/true-self-sim/front/src/hook/useMyStory.ts
+++ b/true-self-sim/front/src/hook/useMyStory.ts
@@ -1,8 +1,9 @@
 import {useSuspenseQuery} from "@tanstack/react-query";
 import {getMyStory} from "../api/myScene.ts";
+import type {PrivateStory} from "../types.ts";
 
 const useMyStory = () => {
-    return useSuspenseQuery({
+    return useSuspenseQuery<PrivateStory>({
         queryKey: ['myStory'],
         queryFn: getMyStory,
     });

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -28,7 +28,7 @@ const PrivateAdmin: React.FC = () => {
 
     useEffect(() => {
         if (!currentId) return;
-        const sc = data?.publicScenes.find(s => s.sceneId === currentId);
+        const sc = data?.privateScenes.find(s => s.sceneId === currentId);
         if (sc) {
             setRequest({
                 sceneId: sc.sceneId,
@@ -37,7 +37,7 @@ const PrivateAdmin: React.FC = () => {
                 text: sc.text,
                 choiceRequests: Array.isArray(sc.texts)
                     ? sc.texts.map(t => ({
-                        nextSceneId: t.nextPublicSceneId,
+                        nextSceneId: t.nextPrivateSceneId,
                         text: t.text
                     }))
                     : [],
@@ -77,7 +77,7 @@ const PrivateAdmin: React.FC = () => {
                         로그아웃
                     </button>
                     <ul className="space-y-2">
-                        {data?.publicScenes?.map((sc) => (
+                        {data?.privateScenes?.map((sc) => (
                             <li key={sc.sceneId}>
                                 <button
                                     onClick={() => setCurrentId(sc.sceneId)}

--- a/true-self-sim/front/src/types.ts
+++ b/true-self-sim/front/src/types.ts
@@ -62,3 +62,25 @@ export interface RegisterRequest {
     phoneNumber: string;
     email: string;
 }
+
+export interface PrivateChoice {
+    text: string;
+    nextPrivateSceneId: string;
+    nextText: string;
+}
+
+export interface PrivateScene {
+    sceneId: string;
+    speaker: string;
+    backgroundImage: string;
+    text: string;
+    texts: PrivateChoice[];
+    start: boolean;
+    end: boolean;
+}
+
+export interface PrivateStory {
+    isSuccess: boolean;
+    message: string;
+    privateScenes: PrivateScene[];
+}


### PR DESCRIPTION
## Summary
- support private story data by defining PrivateScene, PrivateChoice, and PrivateStory interfaces
- update `getMyStory` and `useMyStory` to use `PrivateStory`
- load `privateScenes` in PrivateAdmin and use `nextPrivateSceneId` for choices

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d34b6c98883239f26dffbf08f26e1