### PR TITLE
Add advanced private scene editor

### DIFF
--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -1,4 +1,4 @@
-import type {PublicSceneRequest, PrivateStory} from "../types.ts";
+import type {PrivateSceneRequest, PrivateStory} from "../types.ts";
 import api from "./api.ts";
 
 export const getMyStory = async (): Promise<PrivateStory> => {
@@ -6,7 +6,7 @@ export const getMyStory = async (): Promise<PrivateStory> => {
     return res.data;
 }
 
-export const postMyScene = async (data: PublicSceneRequest) => {
+export const postMyScene = async (data: PrivateSceneRequest) => {
     const res = await api.post(`/my/scene/${data.sceneId}`, data);
     return res.data;
 }

--- a/true-self-sim/front/src/hook/usePostMyScene.ts
+++ b/true-self-sim/front/src/hook/usePostMyScene.ts
@@ -1,10 +1,10 @@
 import {useMutation} from "@tanstack/react-query";
-import type {PublicSceneRequest} from "../types.ts";
+import type {PrivateSceneRequest} from "../types.ts";
 import {postMyScene} from "../api/myScene.ts";
 
 const usePostMyScene = () => {
     return useMutation({
-        mutationFn: (data: PublicSceneRequest) => postMyScene(data)
+        mutationFn: (data: PrivateSceneRequest) => postMyScene(data)
     });
 }
 

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -2,9 +2,10 @@ import useMyStory from "../hook/useMyStory.ts";
 import usePostMyScene from "../hook/usePostMyScene.ts";
 import useDeleteMyScene from "../hook/useDeleteMyScene.ts";
 import {useContext, useEffect, useState} from "react";
-import type {PublicSceneRequest} from "../types.ts";
+import type {PrivateSceneRequest} from "../types.ts";
 import {useNavigate} from "react-router-dom";
 import AuthContext from "../context/AuthContext.tsx";
+import { backgroundImgs } from "../constants/backgroundImages.ts";
 
 const PrivateAdmin: React.FC = () => {
     const navigate = useNavigate();
@@ -16,7 +17,7 @@ const PrivateAdmin: React.FC = () => {
     if (error) navigate("/login");
 
     const [currentId, setCurrentId] = useState("");
-    const [request, setRequest] = useState<PublicSceneRequest>({
+    const [request, setRequest] = useState<PrivateSceneRequest>({
         sceneId: "",
         speaker: "",
         backgroundImage: "",
@@ -25,6 +26,32 @@ const PrivateAdmin: React.FC = () => {
         start: false,
         end: false,
     });
+    const [useCustomImg, setUseCustomImg] = useState(false);
+
+    const otherSceneAlreadyStart = data?.privateScenes?.some(
+        scene => scene.start && scene.sceneId !== currentId
+    );
+
+    const createNew = () => {
+        setCurrentId("");
+        setRequest({
+            sceneId: "",
+            speaker: "",
+            backgroundImage: "",
+            text: "",
+            choiceRequests: [],
+            start: false,
+            end: false,
+        });
+        setUseCustomImg(false);
+    };
+
+    const addChoice = () => {
+        setRequest(r => ({
+            ...r,
+            choiceRequests: [...r.choiceRequests, { text: "", nextSceneId: null }]
+        }));
+    };
 
     useEffect(() => {
         if (!currentId) return;
@@ -44,6 +71,7 @@ const PrivateAdmin: React.FC = () => {
                 start: sc.start,
                 end: sc.end,
             });
+            setUseCustomImg(!backgroundImgs.includes(sc.backgroundImage));
         }
     }, [currentId, data]);
 
@@ -76,6 +104,12 @@ const PrivateAdmin: React.FC = () => {
                     >
                         로그아웃
                     </button>
+                    <button
+                        className="mb-2 w-full py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition"
+                        onClick={createNew}
+                    >
+                        + 새 장면
+                    </button>
                     <ul className="space-y-2">
                         {data?.privateScenes?.map((sc) => (
                             <li key={sc.sceneId}>
@@ -96,45 +130,164 @@ const PrivateAdmin: React.FC = () => {
                             type="text"
                             className="mt-1 w-full border rounded p-2"
                             value={request.sceneId}
-                            onChange={(e) => setRequest((r) => ({ ...r, sceneId: e.target.value }))}
+                            onChange={(e) => setRequest(r => ({ ...r, sceneId: e.target.value }))}
+                            placeholder="예: s01"
                         />
                     </div>
-                    <div>
-                        <label className="block text-sm font-medium">Speaker</label>
-                        <input
-                            type="text"
-                            className="mt-1 w-full border rounded p-2"
-                            value={request.speaker}
-                            onChange={(e) => setRequest((r) => ({ ...r, speaker: e.target.value }))}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium">Background Image</label>
-                        <input
-                            type="text"
-                            className="mt-1 w-full border rounded p-2"
-                            value={request.backgroundImage}
-                            onChange={(e) => setRequest((r) => ({ ...r, backgroundImage: e.target.value }))}
-                            placeholder="https://example.com/bg.jpg"
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium">Text</label>
+
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium">text</label>
                         <textarea
                             className="mt-1 w-full border rounded p-2 h-32"
+                            placeholder="장면 내용을 입력하세요..."
                             value={request.text}
-                            onChange={(e) => setRequest((r) => ({ ...r, text: e.target.value }))}
+                            onChange={(e) => setRequest(r => ({ ...r, text: e.target.value }))}
                         />
                     </div>
-                    <div className="flex space-x-2">
-                        <button className="px-4 py-2 bg-blue-600 text-white rounded-lg" onClick={handleSave}>
+
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+                        <div>
+                            <label className="block text-sm font-medium">화자</label>
+                            <input
+                                type="text"
+                                className="mt-1 w-full border rounded p-2"
+                                value={request.speaker}
+                                onChange={(e) => setRequest(r => ({ ...r, speaker: e.target.value }))}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-1">배경이미지</label>
+                            <label className="inline-flex items-center mb-2 space-x-2">
+                                <input
+                                    type="checkbox"
+                                    checked={useCustomImg}
+                                    onChange={(e) => setUseCustomImg(e.target.checked)}
+                                />
+                                <span>직접 URL 입력</span>
+                            </label>
+                            <div className="w-full">
+                                {useCustomImg ? (
+                                    <input
+                                        type="text"
+                                        className="w-full border rounded p-2"
+                                        value={request.backgroundImage}
+                                        onChange={(e) => setRequest(r => ({ ...r, backgroundImage: e.target.value }))}
+                                        placeholder="https://example.com/bg.jpg"
+                                    />
+                                ) : (
+                                    <select
+                                        className="w-full border rounded p-2"
+                                        value={request.backgroundImage}
+                                        onChange={(e) => setRequest(r => ({ ...r, backgroundImage: e.target.value }))}
+                                    >
+                                        <option value="">배경 이미지 선택</option>
+                                        {backgroundImgs.map((img, index) => (
+                                            <option key={index} value={img}>{img}</option>
+                                        ))}
+                                    </select>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mb-4">
+                        <div className="flex justify-between items-center mb-2">
+                            <label className="text-sm font-medium">Choice</label>
+                            {data?.privateScenes?.length > 0 && (
+                                <button className="text-sm text-green-600" onClick={addChoice}>+ 추가</button>
+                            )}
+                        </div>
+                        {request.choiceRequests.length === 0 && (
+                            <p className="text-sm text-gray-400">선택지를 추가하려면 "+ 추가" 버튼을 누르세요.</p>
+                        )}
+                        {request.choiceRequests.map((choice, index) => (
+                            <div className="space-y-2" key={index}>
+                                <div className="flex flex-col sm:flex-row sm:space-x-2 space-y-2 sm:space-y-0">
+                                    <input
+                                        type="text"
+                                        placeholder="답변 텍스트"
+                                        className="border rounded p-1 flex-1"
+                                        value={choice.text}
+                                        onChange={(e) =>
+                                            setRequest(r => ({
+                                                ...r,
+                                                choiceRequests: r.choiceRequests.map((c, i) => i === index ? { ...c, text: e.target.value } : c)
+                                            }))
+                                        }
+                                    />
+                                    <select
+                                        className="border rounded p-1 flex-1"
+                                        value={choice.nextSceneId ?? ''}
+                                        onChange={(e) =>
+                                            setRequest(r => ({
+                                                ...r,
+                                                choiceRequests: r.choiceRequests.map((c, i) => i === index ? { ...c, nextSceneId: e.target.value } : c)
+                                            }))
+                                        }
+                                    >
+                                        <option value="" disabled>다음 장면 선택</option>
+                                        {data?.privateScenes?.filter(scene => scene.sceneId !== currentId)
+                                            .map(scene => (
+                                                <option key={scene.sceneId} value={scene.sceneId}>
+                                                    [{scene.sceneId}] {scene.text.length > 20 ? scene.text.slice(0, 20) + '...' : scene.text}
+                                                </option>
+                                            ))}
+                                    </select>
+                                    <button
+                                        className="text-red-600 self-center"
+                                        onClick={() => setRequest(r => ({
+                                            ...r,
+                                            choiceRequests: r.choiceRequests.filter((_, i) => i !== index)
+                                        }))}
+                                    >
+                                        x
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row sm:space-x-4 mb-4">
+                        {otherSceneAlreadyStart && !request.start && (
+                            <p className="text-xs text-gray-500 ml-6 mt-1">
+                                시작 장면은 하나만 지정할 수 있습니다.
+                            </p>
+                        )}
+                        <label className={`inline-flex items-center space-x-2 ${otherSceneAlreadyStart ? 'opacity-50 pointer-events-none' : ''}`}>
+                            <input
+                                type="checkbox"
+                                className="form-checkbox"
+                                checked={request.start}
+                                onChange={(e) => setRequest(r => ({ ...r, start: e.target.checked }))}
+                            />
+                            <span>Start Scene</span>
+                        </label>
+                        <label className="inline-flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                className="form-checkbox"
+                                checked={request.end}
+                                onChange={(e) => setRequest(r => ({ ...r, end: e.target.checked }))}
+                            />
+                            <span>End Scene</span>
+                        </label>
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row sm:space-x-2 space-y-2 sm:space-y-0">
+                        <button className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-lg" onClick={handleSave}>
                             저장
                         </button>
                         {currentId && (
-                            <button className="px-4 py-2 bg-red-600 text-white rounded-lg" onClick={handleDelete}>
+                            <button className="w-full sm:w-auto px-4 py-2 bg-red-600 text-white rounded-lg" onClick={handleDelete}>
                                 삭제
                             </button>
                         )}
+                        <button
+                            className="w-full sm:w-auto px-4 py-2 bg-gray-400 text-white rounded-lg"
+                            onClick={() => setRequest({ sceneId: '', speaker: '', backgroundImage: '', text: '', choiceRequests: [], start: false, end: false })}
+                        >
+                            입력 초기화
+                        </button>
                     </div>
                 </section>
             </div>

--- a/true-self-sim/front/src/types.ts
+++ b/true-self-sim/front/src/types.ts
@@ -84,3 +84,18 @@ export interface PrivateStory {
     message: string;
     privateScenes: PrivateScene[];
 }
+
+export interface PrivateChoiceRequest {
+    nextSceneId: string | null;
+    text: string;
+}
+
+export interface PrivateSceneRequest {
+    sceneId?: string;
+    speaker: string;
+    backgroundImage: string;
+    text: string;
+    choiceRequests: PrivateChoiceRequest[];
+    start: boolean;
+    end: boolean;
+}


### PR DESCRIPTION
## Summary
- support private scenes editing with new fields and UI
- allow selecting background images and managing choices
- add definitions for private scene requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d37ed6d088323a3a37089d362a4d0