### PR TITLE
Add private game page

### DIFF
--- a/true-self-sim/front/src/App.tsx
+++ b/true-self-sim/front/src/App.tsx
@@ -3,11 +3,13 @@ import AuthProvider from "./provider/AuthProvider.tsx";
 import {lazy, Suspense} from "react";
 import LoadingScreen from "./pages/LoadingScreen.tsx";
 import ErrorBoundary from "./pages/ErrorBoundary.tsx";
+import PrivateRoute from "./component/PrivateRoute.tsx";
 
 function App() {
     const Login = lazy(() => import("./pages/Login.tsx"))
     const Register = lazy(() => import("./pages/Register.tsx"))
     const PublicGame = lazy(() => import("./pages/PublicGame.tsx"))
+    const PrivateGame = lazy(() => import("./pages/PrivateGame.tsx"))
     const PublicAdmin = lazy(() => import("./pages/PublicAdmin.tsx"))
     const PublicAdminGraph = lazy(() => import("./pages/PublicAdminGraph.tsx"))
 
@@ -20,6 +22,7 @@ function App() {
                           <Route path={"/"} element={<PublicGame/>}/>
                           <Route path={"/login"} element={<Login/>}/>
                           <Route path={"/register"} element={<Register/>}/>
+                          <Route path={"/game"} element={<PrivateRoute><PrivateGame/></PrivateRoute>}/>
                           <Route path={"/admin/public"} element={<PublicAdmin/>}/>
                           <Route path={"/admin/public/graph"} element={<PublicAdminGraph/>}/>
                       </Routes>

--- a/true-self-sim/front/src/component/PrivateRoute.tsx
+++ b/true-self-sim/front/src/component/PrivateRoute.tsx
@@ -1,0 +1,15 @@
+import { useContext } from "react";
+import { Navigate } from "react-router-dom";
+import AuthContext from "../context/AuthContext.tsx";
+
+const PrivateRoute: React.FC<{ children: JSX.Element }> = ({ children }) => {
+    const { user, loading } = useContext(AuthContext);
+
+    if (loading) {
+        return <div>로딩 중...</div>;
+    }
+
+    return user ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/true-self-sim/front/src/pages/PrivateGame.tsx
+++ b/true-self-sim/front/src/pages/PrivateGame.tsx
@@ -1,0 +1,109 @@
+import { useNavigate } from "react-router-dom";
+import { useContext, useEffect, useState } from "react";
+import AuthContext from "../context/AuthContext.tsx";
+import usePublicFirstScene from "../hook/usePublicFirstScene.ts";
+import type { PublicScene } from "../types.ts";
+import { getPublicScene } from "../api/publicScene.ts";
+import MemoryLog from "../component/MemoryLog.tsx";
+import FullLog from "../component/FullLog.tsx";
+
+const PrivateGame: React.FC = () => {
+    const navigate = useNavigate();
+    const { user, logout, refreshUser, loading } = useContext(AuthContext);
+    const { data: firstScene } = usePublicFirstScene();
+    const [scene, setScene] = useState<PublicScene>({
+        sceneId: "",
+        speaker: "",
+        backgroundImage: "",
+        text: "",
+        texts: [],
+        start: false,
+        end: false,
+    });
+
+    const [log, setLog] = useState<string[]>([]);
+    const [fullLog, setFullLog] = useState<string[]>([]);
+    const [isFinished, setIsFinished] = useState(false);
+
+    useEffect(() => {
+        if (!loading && !user) {
+            navigate("/login");
+        }
+    }, [loading, user, navigate]);
+
+    useEffect(() => {
+        if (firstScene) {
+            setScene(firstScene);
+        }
+        setIsFinished(firstScene.end);
+    }, [firstScene]);
+
+    const handleNextScene = async (nextSceneId: string, nextText: string) => {
+        setFullLog(full => [`${scene.speaker}: ${scene.text}`, `-> ${user?.name ?? "U"}: ${nextText}`, ...full]);
+        setLog(prev => {
+            const logEntry = [`${scene.speaker}: ${scene.text}`, `-> ${user?.name ?? "U"}: ${nextText}`, ...prev];
+            return logEntry.slice(0, 5);
+        });
+
+        try {
+            const nextScene = await getPublicScene(nextSceneId);
+            setScene(nextScene);
+            setIsFinished(nextScene.end);
+        } catch (err) {
+            console.error("다음 장면을 불러오는 데 실패했습니다:", err);
+        }
+    };
+
+    const isExternalUrl = (url: string) => /^https?:\/\//.test(url);
+    const bgSrc = isExternalUrl(scene.backgroundImage) ? scene.backgroundImage : `background/${scene.backgroundImage}`;
+
+    return (
+        <div className="relative min-h-screen w-full overflow-hidden bg-black text-white flex flex-col md:flex-row">
+            <img className="absolute inset-0 w-full h-full object-cover opacity-50" alt="background" src={bgSrc} />
+            <div className="relative z-10 flex-1 flex flex-col items-center pt-6 px-4 space-y-6 md:items-center md:px-8 lg:px-16 lg:pr-72">
+                <div className="w-full max-w-xl flex justify-between items-center">
+                    <h1 className="text-2xl md:text-3xl font-bold text-indigo-300">
+                        환영합니다, {user?.name}님!
+                    </h1>
+                    <div className="flex space-x-4">
+                        {user?.isAdmin && (
+                            <button className="text-sm md:text-base text-green-400 hover:text-green-600" onClick={() => navigate("/admin/public")}>관리자</button>
+                        )}
+                        <button className="text-sm md:text-base text-red-500 hover:text-red-600" onClick={async () => { await logout(); await refreshUser(); navigate("/login"); }}>
+                            로그아웃
+                        </button>
+                    </div>
+                </div>
+                <div className="bg-white/10 backdrop-blur-md rounded-xl shadow-lg p-6 w-full max-w-xl md:max-w-2xl">
+                    <h2 className="text-indigo-300 text-lg md:text-xl mb-2">{scene.speaker}</h2>
+                    <p className="text-xl md:text-2xl mb-4">{scene.text}</p>
+                    <div className="space-y-2">
+                        {scene?.texts?.map((t, index) => (
+                            <button key={index} onClick={() => handleNextScene(t.nextPublicSceneId, t.text)} className="block w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm md:text-base">
+                                {t.text}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+                {isFinished && (
+                    <FullLog
+                        log={fullLog}
+                        onRestart={() => {
+                            setLog([]);
+                            setFullLog([]);
+                            setIsFinished(false);
+                            if (firstScene) setScene(firstScene);
+                        }}
+                    />
+                )}
+            </div>
+            {!isFinished && (
+                <div className="hidden lg:block lg:fixed lg:top-4 lg:right-4 lg:w-64 lg:h-[70vh] overflow-y-auto">
+                    <MemoryLog log={log} />
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default PrivateGame;


### PR DESCRIPTION
## Summary
- implement `PrivateRoute` and `PrivateGame` pages on frontend
- enable `/game` route behind authentication

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685d39db857083238851e654bb447b31