### PR TITLE
Improve save validation for admin graphs

### DIFF
--- a/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
@@ -264,6 +264,13 @@ const PrivateAdminGraph: React.FC = () => {
         setErrorMsg('');
         setSuccessMsg('');
         setInvalidNodes({});
+        for (const e of edges) {
+            const label = e.label as string | undefined;
+            if (!label || !label.trim()) {
+                setErrorMsg('label이 비어 있는 edge가 있습니다');
+                return;
+            }
+        }
         const requests = toRequests(nodes, edges);
 
         for (const scene of requests) {

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -264,6 +264,13 @@ const PublicAdminGraph: React.FC = () => {
         setErrorMsg('');
         setSuccessMsg('');
         setInvalidNodes({});
+        for (const e of edges) {
+            const label = e.label as string | undefined;
+            if (!label || !label.trim()) {
+                setErrorMsg('label이 비어 있는 edge가 있습니다');
+                return;
+            }
+        }
         const requests = toRequests(nodes, edges);
 
         for (const scene of requests) {


### PR DESCRIPTION
## Summary
- prevent saving private/public admin graphs if any edge is unlabeled
- show warning `label이 비어 있는 edge가 있습니다`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685dfe1334c0832390275e3c731f5433