### PR TITLE
Fix type-only imports and mutation hooks

### DIFF
--- a/true-self-sim/front/src/component/AdminGraph.tsx
+++ b/true-self-sim/front/src/component/AdminGraph.tsx
@@ -18,7 +18,8 @@ import type {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-import EditableNode, { EditableNodeData, NodeFormData } from './EditableNode';
+import EditableNode from './EditableNode';
+import type { EditableNodeData, NodeFormData } from './EditableNode';
 import { backgroundImgs } from '../constants/backgroundImages';
 import CurvedEdge from './CurvedEdge';
 import { useNavigate } from 'react-router-dom';
@@ -36,8 +37,14 @@ export interface GraphScene {
 
 export interface AdminGraphProps {
     useStory: () => { data?: any };
-    useSaveBulk: () => { mutate: (reqs: any[]) => void; isPending?: boolean };
-    useDeleteScene: () => { mutate: (id: string) => void; isPending?: boolean };
+    useSaveBulk: () => {
+        mutate: (reqs: any[], options?: { onSuccess?: () => void; onError?: () => void }) => void;
+        isPending?: boolean;
+    };
+    useDeleteScene: () => {
+        mutate: (id: string, options?: { onSuccess?: () => void; onError?: () => void }) => void;
+        isPending?: boolean;
+    };
     selectScenes: (data: any) => GraphScene[];
     backPath: string;
 }

--- a/true-self-sim/front/src/component/PrivateRoute.tsx
+++ b/true-self-sim/front/src/component/PrivateRoute.tsx
@@ -1,8 +1,9 @@
 import { useContext } from "react";
+import type { ReactElement } from "react";
 import { Navigate } from "react-router-dom";
 import AuthContext from "../context/AuthContext.tsx";
 
-const PrivateRoute: React.FC<{ children: JSX.Element }> = ({ children }) => {
+const PrivateRoute: React.FC<{ children: ReactElement }> = ({ children }) => {
     const { user, loading } = useContext(AuthContext);
 
     if (loading) {

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -6,7 +6,8 @@ import useDeleteMyScene from "../hook/useDeleteMyScene.ts";
 import AuthContext from "../context/AuthContext.tsx";
 import { backgroundImgs } from "../constants/backgroundImages.ts";
 import AdminSidebar from "../component/AdminSidebar";
-import AdminEditorForm, { SceneRequest } from "../component/AdminEditorForm";
+import AdminEditorForm from "../component/AdminEditorForm";
+import type { SceneRequest } from "../component/AdminEditorForm";
 import type { PrivateSceneRequest } from "../types.ts";
 
 const PrivateAdmin: React.FC = () => {

--- a/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
@@ -1,4 +1,5 @@
-import AdminGraph, { GraphScene } from "../component/AdminGraph";
+import AdminGraph from "../component/AdminGraph";
+import type { GraphScene } from "../component/AdminGraph";
 import useMyStory from "../hook/useMyStory.ts";
 import usePostMySceneBulk from "../hook/usePostMySceneBulk.ts";
 import useDeleteMyScene from "../hook/useDeleteMyScene.ts";

--- a/true-self-sim/front/src/pages/PublicAdmin.tsx
+++ b/true-self-sim/front/src/pages/PublicAdmin.tsx
@@ -5,9 +5,9 @@ import usePostPublicScene from "../hook/usePostPublicScene.ts";
 import useDeletePublicScene from "../hook/useDeletePublicScene.ts";
 import usePostPublicSceneBulk from "../hook/usePostPublicSceneBulk.ts";
 import AuthContext from "../context/AuthContext.tsx";
-import { backgroundImgs } from "../constants/backgroundImages.ts";
 import AdminSidebar from "../component/AdminSidebar";
-import AdminEditorForm, { SceneRequest } from "../component/AdminEditorForm";
+import AdminEditorForm from "../component/AdminEditorForm";
+import type { SceneRequest } from "../component/AdminEditorForm";
 import type { PublicSceneRequest } from "../types.ts";
 
 const emptyRequest: PublicSceneRequest = {

--- a/true-self-sim/front/src/pages/PublicAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PublicAdminGraph.tsx
@@ -1,4 +1,5 @@
-import AdminGraph, { GraphScene } from "../component/AdminGraph";
+import AdminGraph from "../component/AdminGraph";
+import type { GraphScene } from "../component/AdminGraph";
 import usePublicStory from "../hook/usePublicStory.ts";
 import usePostPublicSceneBulk from "../hook/usePostPublicSceneBulk.ts";
 import useDeletePublicScene from "../hook/useDeletePublicScene.ts";


### PR DESCRIPTION
## Summary
- fix type imports for TS with `verbatimModuleSyntax`
- allow mutation hooks to accept option argument

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e12e9cd708323b507fecc363a6123