### PR TITLE
Add user-specific private game URL

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/controller/UserStoryController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/UserStoryController.java
@@ -1,0 +1,34 @@
+package com.self_true.controller;
+
+import com.self_true.service.PrivateStoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+@Tag(name = "UserStoryController", description = "다른 사용자 개인 스토리 API")
+public class UserStoryController {
+
+    private final PrivateStoryService privateStoryService;
+
+    public UserStoryController(PrivateStoryService privateStoryService) {
+        this.privateStoryService = privateStoryService;
+    }
+
+    @Operation(summary = "사용자 첫 장면 호출")
+    @GetMapping("/{memberId}/scene")
+    public ResponseEntity<?> getFirst(@PathVariable String memberId,
+                                      @AuthenticationPrincipal String viewerId) {
+        return ResponseEntity.ok(privateStoryService.getFirstScene(memberId, viewerId));
+    }
+
+    @Operation(summary = "사용자 특정 장면 호출")
+    @GetMapping("/{memberId}/scene/{id}")
+    public ResponseEntity<?> getScene(@PathVariable String memberId, @PathVariable String id,
+                                      @AuthenticationPrincipal String viewerId) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, memberId, viewerId));
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -52,7 +52,11 @@ public class PrivateStoryService {
     }
 
     public PrivateSceneResponse getFirstScene(String memberId) {
-        Long userId = memberService.findById(memberId).map(Member::getId).orElse(null);
+        return getFirstScene(memberId, memberId);
+    }
+
+    public PrivateSceneResponse getFirstScene(String targetMemberId, String logMemberId) {
+        Long userId = memberService.findById(targetMemberId).map(Member::getId).orElse(null);
         PrivateSceneResponse response = Optional.ofNullable(userId)
                 .flatMap(id -> sceneRepository.findFirstByMemberIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(id))
                 .map(PrivateSceneResponse::fromEntity)
@@ -65,17 +69,21 @@ public class PrivateStoryService {
                         .isEnd(false)
                         .build());
         response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), userId));
-        if (userId != null) saveSceneLog(memberId, response);
+        if (logMemberId != null) saveSceneLog(logMemberId, response);
         return response;
     }
 
     public PrivateSceneResponse getPrivateScene(String id, String memberId) {
-        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        return getPrivateScene(id, memberId, memberId);
+    }
+
+    public PrivateSceneResponse getPrivateScene(String id, String targetMemberId, String logMemberId) {
+        Long userId = memberService.findById(targetMemberId).map(Member::getId).orElseThrow();
         PrivateSceneResponse response = sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
                 .map(PrivateSceneResponse::fromEntity)
                 .orElseThrow(() -> new NotFoundSceneException("not found scene id: " + id));
         response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), userId));
-        saveSceneLog(memberId, response);
+        saveSceneLog(logMemberId, response);
         return response;
     }
 

--- a/true-self-sim/front/src/App.tsx
+++ b/true-self-sim/front/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
                           <Route path={"/"} element={<PublicGame/>}/>
                           <Route path={"/login"} element={<Login/>}/>
                           <Route path={"/register"} element={<Register/>}/>
-                          <Route path={"/game"} element={<PrivateRoute><PrivateGame/></PrivateRoute>}/>
+                          <Route path={"/game/:id"} element={<PrivateRoute><PrivateGame/></PrivateRoute>}/>
                           <Route path={"/admin/public"} element={<PublicAdmin/>}/>
                         <Route path={"/admin/public/graph"} element={<PublicAdminGraph/>}/>
                         <Route path={"/my"} element={<PrivateAdmin/>}/>

--- a/true-self-sim/front/src/api/privateScene.ts
+++ b/true-self-sim/front/src/api/privateScene.ts
@@ -1,12 +1,14 @@
 import type { PrivateScene } from "../types.ts";
 import api from "./api.ts";
 
-export const getPrivateFirstScene = async (): Promise<PrivateScene> => {
-    const res = await api.get<PrivateScene>("/my/scene");
+export const getPrivateFirstScene = async (memberId?: string): Promise<PrivateScene> => {
+    const url = memberId ? `/user/${memberId}/scene` : "/my/scene";
+    const res = await api.get<PrivateScene>(url);
     return res.data;
 };
 
-export const getPrivateScene = async (id: string): Promise<PrivateScene> => {
-    const res = await api.get<PrivateScene>(`/my/scene/${id}`);
+export const getPrivateScene = async (id: string, memberId?: string): Promise<PrivateScene> => {
+    const url = memberId ? `/user/${memberId}/scene/${id}` : `/my/scene/${id}`;
+    const res = await api.get<PrivateScene>(url);
     return res.data;
 };

--- a/true-self-sim/front/src/hook/usePrivateFirstScene.ts
+++ b/true-self-sim/front/src/hook/usePrivateFirstScene.ts
@@ -1,10 +1,10 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getPrivateFirstScene } from "../api/privateScene.ts";
 
-const usePrivateFirstScene = () => {
+const usePrivateFirstScene = (memberId?: string) => {
     return useSuspenseQuery({
-        queryKey: ["usePrivateFirstScene"],
-        queryFn: getPrivateFirstScene,
+        queryKey: ["usePrivateFirstScene", memberId],
+        queryFn: () => getPrivateFirstScene(memberId),
     });
 };
 

--- a/true-self-sim/front/src/pages/PrivateGame.tsx
+++ b/true-self-sim/front/src/pages/PrivateGame.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useContext, useEffect, useState } from "react";
 import AuthContext from "../context/AuthContext.tsx";
 import usePrivateFirstScene from "../hook/usePrivateFirstScene.ts";
@@ -11,8 +11,9 @@ import { backgroundSrc } from "../utils/url.ts";
 
 const PrivateGame: React.FC = () => {
     const navigate = useNavigate();
+    const { id } = useParams();
     const { user, loading } = useContext(AuthContext);
-    const { data: firstScene } = usePrivateFirstScene();
+    const { data: firstScene } = usePrivateFirstScene(id);
     const [scene, setScene] = useState<PrivateScene>({
         sceneId: "",
         speaker: "",
@@ -38,7 +39,7 @@ const PrivateGame: React.FC = () => {
             setScene(firstScene);
         }
         setIsFinished(firstScene.end);
-    }, [firstScene]);
+    }, [firstScene, id]);
 
     const handleNextScene = async (nextSceneId: string, nextText: string) => {
         setFullLog(full => [`${scene.speaker}: ${scene.text}`, `-> ${user?.name ?? "U"}: ${nextText}`, ...full]);
@@ -48,7 +49,7 @@ const PrivateGame: React.FC = () => {
         });
 
         try {
-            const nextScene = await getPrivateScene(nextSceneId);
+            const nextScene = await getPrivateScene(nextSceneId, id);
             setScene(nextScene);
             setIsFinished(nextScene.end);
         } catch (err) {


### PR DESCRIPTION
## Summary
- add API endpoints to access other users' private stories
- extend PrivateStoryService to support target and viewer ids
- fetch user-specific private scenes in frontend
- pass user id parameter through PrivateGame route

## Testing
- `sh gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685e16371e748323a862db3bd5c3d171