### PR TITLE
Support multiple private stories

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
@@ -23,45 +23,58 @@ public class MyController {
         this.privateStoryService = privateStoryService;
     }
 
+    @Operation(summary = "내 스토리 목록 조회")
+    @GetMapping("/stories")
+    public ResponseEntity<?> getStories(@AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getStories(memberId));
+    }
+
     @Operation(summary = "내 장면 저장")
-    @PostMapping("/scene/{id}")
+    @PostMapping("/story/{storyId}/scene/{id}")
     public ResponseEntity<Response> createOrUpdate(@PathVariable String id,
                                                    @RequestBody PrivateSceneRequest request,
+                                                   @PathVariable Long storyId,
                                                    @AuthenticationPrincipal String memberId) {
-        privateStoryService.createOrUpdate(request, id, memberId);
+        privateStoryService.createOrUpdate(request, id, storyId, memberId);
         return ResponseEntity.ok(new Response(true, "장면 저장 완료"));
     }
 
-    @PostMapping("/scenes/bulk")
+    @PostMapping("/story/{storyId}/scenes/bulk")
     public ResponseEntity<Response> saveBulk(@RequestBody List<PrivateSceneRequest> requests,
+                                             @PathVariable Long storyId,
                                              @AuthenticationPrincipal String memberId) {
-        privateStoryService.saveAll(requests, memberId);
+        privateStoryService.saveAll(requests, storyId, memberId);
         return ResponseEntity.ok(new Response(true, "벌크 장면 저장 완료"));
     }
 
     @Operation(summary = "내 장면 삭제")
-    @DeleteMapping("/scene/{id}")
+    @DeleteMapping("/story/{storyId}/scene/{id}")
     public ResponseEntity<Response> delete(@PathVariable String id,
+                                           @PathVariable Long storyId,
                                            @AuthenticationPrincipal String memberId) {
-        privateStoryService.delete(id, memberId);
+        privateStoryService.delete(id, storyId, memberId);
         return ResponseEntity.ok(new Response(true, "장면 삭제 완료"));
     }
 
     @Operation(summary = "내 장면 전체 조회")
-    @GetMapping("/story")
-    public ResponseEntity<PrivateStoryResponse> getStory(@AuthenticationPrincipal String memberId) {
-        return ResponseEntity.ok(privateStoryService.getPrivateScenes(memberId));
+    @GetMapping("/story/{storyId}")
+    public ResponseEntity<PrivateStoryResponse> getStory(@PathVariable Long storyId,
+                                                         @AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScenes(storyId, memberId));
     }
 
     @Operation(summary = "내 첫 장면 호출")
-    @GetMapping("/scene")
-    public ResponseEntity<?> getFirst(@AuthenticationPrincipal String memberId) {
-        return ResponseEntity.ok(privateStoryService.getFirstScene(memberId));
+    @GetMapping("/story/{storyId}/scene")
+    public ResponseEntity<?> getFirst(@PathVariable Long storyId,
+                                      @AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getFirstScene(storyId, memberId));
     }
 
     @Operation(summary = "내 특정 장면 호출")
-    @GetMapping("/scene/{id}")
-    public ResponseEntity<?> getScene(@PathVariable String id, @AuthenticationPrincipal String memberId) {
-        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, memberId));
+    @GetMapping("/story/{storyId}/scene/{id}")
+    public ResponseEntity<?> getScene(@PathVariable String id,
+                                      @PathVariable Long storyId,
+                                      @AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, storyId, memberId));
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/controller/UserStoryController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/UserStoryController.java
@@ -18,17 +18,25 @@ public class UserStoryController {
         this.privateStoryService = privateStoryService;
     }
 
+    @Operation(summary = "사용자 스토리 목록 조회")
+    @GetMapping("/{memberId}/stories")
+    public ResponseEntity<?> getStories(@PathVariable String memberId) {
+        return ResponseEntity.ok(privateStoryService.getStories(memberId));
+    }
+
     @Operation(summary = "사용자 첫 장면 호출")
-    @GetMapping("/{memberId}/scene")
+    @GetMapping("/{memberId}/story/{storyId}/scene")
     public ResponseEntity<?> getFirst(@PathVariable String memberId,
+                                      @PathVariable Long storyId,
                                       @AuthenticationPrincipal String viewerId) {
-        return ResponseEntity.ok(privateStoryService.getFirstScene(memberId, viewerId));
+        return ResponseEntity.ok(privateStoryService.getFirstScene(storyId, memberId, viewerId));
     }
 
     @Operation(summary = "사용자 특정 장면 호출")
-    @GetMapping("/{memberId}/scene/{id}")
-    public ResponseEntity<?> getScene(@PathVariable String memberId, @PathVariable String id,
+    @GetMapping("/{memberId}/story/{storyId}/scene/{id}")
+    public ResponseEntity<?> getScene(@PathVariable String memberId, @PathVariable Long storyId,
+                                      @PathVariable String id,
                                       @AuthenticationPrincipal String viewerId) {
-        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, memberId, viewerId));
+        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, storyId, memberId, viewerId));
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateChoiceRequest.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateChoiceRequest.java
@@ -8,11 +8,14 @@ public class PrivateChoiceRequest {
     private String nextSceneId;
     private String text;
 
-    public PrivateChoice toEntity(String privateSceneId, Long memberId) {
+    private Long storyId;
+
+    public PrivateChoice toEntity(String privateSceneId, Long storyId, Long memberId) {
         return PrivateChoice.builder()
                 .text(this.text)
                 .nextPrivateSceneId(this.nextSceneId)
                 .privateSceneId(privateSceneId)
+                .storyId(storyId)
                 .memberId(memberId)
                 .build();
     }

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateSceneRequest.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateSceneRequest.java
@@ -14,6 +14,7 @@ public class PrivateSceneRequest {
     private String text;
     private boolean isStart = false;
     private boolean isEnd = false;
+    private Long storyId;
     private List<PrivateChoiceRequest> choiceRequests;
 
     public PrivateScene toEntity(Long memberId) {
@@ -24,13 +25,14 @@ public class PrivateSceneRequest {
                 .text(text)
                 .isStart(isStart)
                 .isEnd(isEnd)
+                .storyId(storyId)
                 .memberId(memberId)
                 .build();
     }
 
     public List<PrivateChoice> toChoiceEntities(Long memberId) {
         return choiceRequests.stream()
-                .map(cr -> cr.toEntity(sceneId, memberId))
+                .map(cr -> cr.toEntity(sceneId, storyId, memberId))
                 .toList();
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateScene.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateScene.java
@@ -23,6 +23,8 @@ public class PrivateScene extends BaseEntity {
     private Boolean isStart;
     private Boolean isEnd;
 
+    private Long storyId;
+
     private Long memberId;
 }
 

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateStory.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateStory.java
@@ -7,20 +7,15 @@ import lombok.*;
 @Builder
 @Data
 @Entity
-@EqualsAndHashCode(callSuper = false)
-@NoArgsConstructor
 @AllArgsConstructor
-public class PrivateChoice extends BaseEntity {
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class PrivateStory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String text;
-    private String privateSceneId;
-    private String nextPrivateSceneId;
-
-    private Long storyId;
-
     private Long memberId;
-}
 
+    private String title;
+}

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateChoiceRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateChoiceRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PrivateChoiceRepository extends JpaRepository<PrivateChoice, Long> {
-    List<PrivateChoice> findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(Long memberId, String privateSceneId);
-    List<PrivateChoice> findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(Long memberId, List<String> privateSceneIds);
+    List<PrivateChoice> findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(Long memberId, Long storyId, String privateSceneId);
+    List<PrivateChoice> findByMemberIdAndStoryIdAndPrivateSceneIdInAndDeletedAtIsNull(Long memberId, Long storyId, List<String> privateSceneIds);
 }

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateSceneRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateSceneRepository.java
@@ -7,11 +7,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PrivateSceneRepository extends JpaRepository<PrivateScene, Long> {
-    List<PrivateScene> findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
+    List<PrivateScene> findAllByMemberIdAndStoryIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId, Long storyId);
 
-    Optional<PrivateScene> findFirstByMemberIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
+    Optional<PrivateScene> findFirstByMemberIdAndStoryIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId, Long storyId);
 
-    Optional<PrivateScene> findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(Long memberId, String privateSceneId);
+    Optional<PrivateScene> findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(Long memberId, Long storyId, String privateSceneId);
 
-    List<PrivateScene> findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(Long memberId, List<String> privateSceneIds);
+    List<PrivateScene> findByMemberIdAndStoryIdAndPrivateSceneIdInAndDeletedAtIsNull(Long memberId, Long storyId, List<String> privateSceneIds);
 }

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateStoryRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateStoryRepository.java
@@ -1,0 +1,12 @@
+package com.self_true.repository;
+
+import com.self_true.model.entity.PrivateStory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PrivateStoryRepository extends JpaRepository<PrivateStory, Long> {
+    List<PrivateStory> findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
+    Optional<PrivateStory> findByIdAndMemberIdAndDeletedAtIsNull(Long id, Long memberId);
+}

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -12,6 +12,8 @@ import com.self_true.model.entity.PrivateScene;
 import com.self_true.repository.PrivateChoiceRepository;
 import com.self_true.repository.PrivateLogRepository;
 import com.self_true.repository.PrivateSceneRepository;
+import com.self_true.repository.PrivateStoryRepository;
+import com.self_true.model.entity.PrivateStory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,16 +30,19 @@ public class PrivateStoryService {
     private final PrivateSceneRepository sceneRepository;
     private final PrivateChoiceRepository choiceRepository;
     private final PrivateLogRepository logRepository;
+    private final PrivateStoryRepository storyRepository;
     private final MemberService memberService;
 
     public PrivateStoryService(
             PrivateSceneRepository sceneRepository,
             PrivateChoiceRepository choiceRepository,
             PrivateLogRepository logRepository,
+            PrivateStoryRepository storyRepository,
             MemberService memberService) {
         this.sceneRepository = sceneRepository;
         this.choiceRepository = choiceRepository;
         this.logRepository = logRepository;
+        this.storyRepository = storyRepository;
         this.memberService = memberService;
     }
 
@@ -51,14 +56,19 @@ public class PrivateStoryService {
                 .ifPresent(logRepository::save);
     }
 
-    public PrivateSceneResponse getFirstScene(String memberId) {
-        return getFirstScene(memberId, memberId);
+    public List<PrivateStory> getStories(String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        return storyRepository.findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
     }
 
-    public PrivateSceneResponse getFirstScene(String targetMemberId, String logMemberId) {
+    public PrivateSceneResponse getFirstScene(Long storyId, String memberId) {
+        return getFirstScene(storyId, memberId, memberId);
+    }
+
+    public PrivateSceneResponse getFirstScene(Long storyId, String targetMemberId, String logMemberId) {
         Long userId = memberService.findById(targetMemberId).map(Member::getId).orElse(null);
         PrivateSceneResponse response = Optional.ofNullable(userId)
-                .flatMap(id -> sceneRepository.findFirstByMemberIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(id))
+                .flatMap(id -> sceneRepository.findFirstByMemberIdAndStoryIdAndIsStartIsTrueAndDeletedAtIsNullOrderByCreatedAtDesc(id, storyId))
                 .map(PrivateSceneResponse::fromEntity)
                 .orElse(PrivateSceneResponse.builder()
                         .sceneId("")
@@ -68,28 +78,28 @@ public class PrivateStoryService {
                         .isStart(false)
                         .isEnd(false)
                         .build());
-        response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), userId));
+        response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), storyId, userId));
         if (logMemberId != null) saveSceneLog(logMemberId, response);
         return response;
     }
 
-    public PrivateSceneResponse getPrivateScene(String id, String memberId) {
-        return getPrivateScene(id, memberId, memberId);
+    public PrivateSceneResponse getPrivateScene(String id, Long storyId, String memberId) {
+        return getPrivateScene(id, storyId, memberId, memberId);
     }
 
-    public PrivateSceneResponse getPrivateScene(String id, String targetMemberId, String logMemberId) {
+    public PrivateSceneResponse getPrivateScene(String id, Long storyId, String targetMemberId, String logMemberId) {
         Long userId = memberService.findById(targetMemberId).map(Member::getId).orElseThrow();
-        PrivateSceneResponse response = sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
+        PrivateSceneResponse response = sceneRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, id)
                 .map(PrivateSceneResponse::fromEntity)
                 .orElseThrow(() -> new NotFoundSceneException("not found scene id: " + id));
-        response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), userId));
+        response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), storyId, userId));
         saveSceneLog(logMemberId, response);
         return response;
     }
 
-    private List<PrivateChoiceResponse> getChoiceResponsesBySceneId(String sceneId, Long memberId) {
+    private List<PrivateChoiceResponse> getChoiceResponsesBySceneId(String sceneId, Long storyId, Long memberId) {
         if (memberId == null) return List.of();
-        return choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(memberId, sceneId).stream()
+        return choiceRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(memberId, storyId, sceneId).stream()
                 .map(pc -> PrivateChoiceResponse.builder()
                         .text(pc.getText())
                         .nextPrivateSceneId(pc.getNextPrivateSceneId())
@@ -97,17 +107,17 @@ public class PrivateStoryService {
                 .toList();
     }
 
-    public void saveAll(List<PrivateSceneRequest> requests, String memberId) {
+    public void saveAll(List<PrivateSceneRequest> requests, Long storyId, String memberId) {
         Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
         List<String> sceneIds = requests.stream().map(PrivateSceneRequest::getSceneId).toList();
-        choiceRepository.findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(userId, sceneIds)
+        choiceRepository.findByMemberIdAndStoryIdAndPrivateSceneIdInAndDeletedAtIsNull(userId, storyId, sceneIds)
                 .forEach(cr -> cr.setDeletedAt(LocalDateTime.now()));
-        List<PrivateScene> existing = sceneRepository.findByMemberIdAndPrivateSceneIdInAndDeletedAtIsNull(userId, sceneIds);
+        List<PrivateScene> existing = sceneRepository.findByMemberIdAndStoryIdAndPrivateSceneIdInAndDeletedAtIsNull(userId, storyId, sceneIds);
         Map<String, PrivateScene> existingMap = existing.stream()
                 .collect(Collectors.toMap(PrivateScene::getPrivateSceneId, Function.identity()));
         List<PrivateScene> scenesToSave = requests.stream().map(req -> {
             PrivateScene scene = existingMap.getOrDefault(req.getSceneId(),
-                    PrivateScene.builder().privateSceneId(req.getSceneId()).memberId(userId).build());
+                    PrivateScene.builder().privateSceneId(req.getSceneId()).memberId(userId).storyId(storyId).build());
             scene.setSpeaker(req.getSpeaker());
             scene.setBackgroundImage(req.getBackgroundImage());
             scene.setText(req.getText());
@@ -117,14 +127,14 @@ public class PrivateStoryService {
         }).toList();
         sceneRepository.saveAll(scenesToSave);
         List<PrivateChoice> choices = requests.stream()
-                .flatMap(r -> r.getChoiceRequests().stream().map(cr -> cr.toEntity(r.getSceneId(), userId)))
+                .flatMap(r -> r.getChoiceRequests().stream().map(cr -> cr.toEntity(r.getSceneId(), storyId, userId)))
                 .toList();
         choiceRepository.saveAll(choices);
     }
 
-    public void createOrUpdate(PrivateSceneRequest request, String id, String memberId) {
+    public void createOrUpdate(PrivateSceneRequest request, String id, Long storyId, String memberId) {
         Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
-        Optional<PrivateScene> opt = sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id);
+        Optional<PrivateScene> opt = sceneRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, id);
         if (opt.isPresent()) {
             PrivateScene entity = opt.get();
             entity.setSpeaker(request.getSpeaker());
@@ -137,22 +147,22 @@ public class PrivateStoryService {
             entity.setPrivateSceneId(id);
             sceneRepository.save(entity);
         }
-        choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
+        choiceRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, id)
                 .forEach(cr -> cr.setDeletedAt(LocalDateTime.now()));
         List<PrivateChoice> choices = request.getChoiceRequests().stream()
                 .map(cr -> {
-                    PrivateChoice entity = cr.toEntity(request.getSceneId(), userId);
+                    PrivateChoice entity = cr.toEntity(request.getSceneId(), storyId, userId);
                     entity.setPrivateSceneId(id);
                     return entity;
                 }).toList();
         choiceRepository.saveAll(choices);
     }
 
-    public void delete(String id, String memberId) {
+    public void delete(String id, Long storyId, String memberId) {
         Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
-        sceneRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, id)
+        sceneRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, id)
                 .ifPresent(scene -> {
-                    choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, scene.getPrivateSceneId())
+                    choiceRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, scene.getPrivateSceneId())
                             .forEach(cr -> cr.setDeletedAt(LocalDateTime.now()));
                     sceneRepository.save(scene);
                     scene.setDeletedAt(LocalDateTime.now());
@@ -160,11 +170,11 @@ public class PrivateStoryService {
     }
 
     @Transactional(readOnly = true)
-    public PrivateStoryResponse getPrivateScenes(String memberId) {
+    public PrivateStoryResponse getPrivateScenes(Long storyId, String memberId) {
         Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
-        PrivateStoryResponse resp = PrivateStoryResponse.fromEntity(sceneRepository.findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId));
+        PrivateStoryResponse resp = PrivateStoryResponse.fromEntity(sceneRepository.findAllByMemberIdAndStoryIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId, storyId));
         resp.getPrivateScenes().forEach(scene -> {
-            List<PrivateChoice> choices = choiceRepository.findByMemberIdAndPrivateSceneIdAndDeletedAtIsNull(userId, scene.getSceneId());
+            List<PrivateChoice> choices = choiceRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, scene.getSceneId());
             List<PrivateChoiceResponse> list = choices.stream()
                     .map(c -> PrivateChoiceResponse.builder().text(c.getText()).nextPrivateSceneId(c.getNextPrivateSceneId()).build())
                     .toList();

--- a/true-self-sim/front/src/App.tsx
+++ b/true-self-sim/front/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
                           <Route path={"/"} element={<PublicGame/>}/>
                           <Route path={"/login"} element={<Login/>}/>
                           <Route path={"/register"} element={<Register/>}/>
-                          <Route path={"/game/:id"} element={<PrivateRoute><PrivateGame/></PrivateRoute>}/>
+                          <Route path={"/game/:memberId/:storyId"} element={<PrivateRoute><PrivateGame/></PrivateRoute>}/>
                           <Route path={"/admin/public"} element={<PublicAdmin/>}/>
                         <Route path={"/admin/public/graph"} element={<PublicAdminGraph/>}/>
                         <Route path={"/my"} element={<PrivateAdmin/>}/>

--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -1,22 +1,27 @@
-import type {PrivateSceneRequest, PrivateStory} from "../types.ts";
+import type {PrivateSceneRequest, PrivateStory, PrivateStoryInfo} from "../types.ts";
 import api from "./api.ts";
 
-export const getMyStory = async (): Promise<PrivateStory> => {
-    const res = await api.get<PrivateStory>("/my/story");
+export const getMyStories = async (): Promise<PrivateStoryInfo[]> => {
+    const res = await api.get<PrivateStoryInfo[]>("/my/stories");
+    return res.data;
+}
+
+export const getMyStory = async (storyId: number): Promise<PrivateStory> => {
+    const res = await api.get<PrivateStory>(`/my/story/${storyId}`);
     return res.data;
 }
 
 export const postMyScene = async (data: PrivateSceneRequest) => {
-    const res = await api.post(`/my/scene/${data.sceneId}`, data);
+    const res = await api.post(`/my/story/${data.storyId}/scene/${data.sceneId}`, data);
     return res.data;
 }
 
-export const deleteMyScene = async (id: string) => {
-    const res = await api.delete(`/my/scene/${id}`);
+export const deleteMyScene = async (id: string, storyId: number) => {
+    const res = await api.delete(`/my/story/${storyId}/scene/${id}`);
     return res.data;
 }
 
-export const postMySceneBulk = async (data: PrivateSceneRequest[]) => {
-    const res = await api.post('/my/scenes/bulk', data);
+export const postMySceneBulk = async (storyId: number, data: PrivateSceneRequest[]) => {
+    const res = await api.post(`/my/story/${storyId}/scenes/bulk`, data);
     return res.data;
 }

--- a/true-self-sim/front/src/api/privateScene.ts
+++ b/true-self-sim/front/src/api/privateScene.ts
@@ -1,14 +1,19 @@
-import type { PrivateScene } from "../types.ts";
+import type { PrivateScene, PrivateStoryInfo } from "../types.ts";
 import api from "./api.ts";
 
-export const getPrivateFirstScene = async (memberId?: string): Promise<PrivateScene> => {
-    const url = memberId ? `/user/${memberId}/scene` : "/my/scene";
+export const getPrivateFirstScene = async (storyId: number, memberId?: string): Promise<PrivateScene> => {
+    const url = memberId ? `/user/${memberId}/story/${storyId}/scene` : `/my/story/${storyId}/scene`;
     const res = await api.get<PrivateScene>(url);
     return res.data;
 };
 
-export const getPrivateScene = async (id: string, memberId?: string): Promise<PrivateScene> => {
-    const url = memberId ? `/user/${memberId}/scene/${id}` : `/my/scene/${id}`;
+export const getPrivateScene = async (id: string, storyId: number, memberId?: string): Promise<PrivateScene> => {
+    const url = memberId ? `/user/${memberId}/story/${storyId}/scene/${id}` : `/my/story/${storyId}/scene/${id}`;
     const res = await api.get<PrivateScene>(url);
+    return res.data;
+};
+
+export const getUserStories = async (memberId: string): Promise<PrivateStoryInfo[]> => {
+    const res = await api.get<PrivateStoryInfo[]>(`/user/${memberId}/stories`);
     return res.data;
 };

--- a/true-self-sim/front/src/hook/useDeleteMyScene.ts
+++ b/true-self-sim/front/src/hook/useDeleteMyScene.ts
@@ -1,9 +1,9 @@
 import {useMutation} from "@tanstack/react-query";
 import {deleteMyScene} from "../api/myScene.ts";
 
-const useDeleteMyScene = () => {
+const useDeleteMyScene = (storyId: number) => {
     return useMutation({
-        mutationFn: (id: string) => deleteMyScene(id)
+        mutationFn: (id: string) => deleteMyScene(id, storyId)
     })
 }
 

--- a/true-self-sim/front/src/hook/useMyStories.ts
+++ b/true-self-sim/front/src/hook/useMyStories.ts
@@ -1,0 +1,12 @@
+import {useSuspenseQuery} from "@tanstack/react-query";
+import {getMyStories} from "../api/myScene.ts";
+import type {PrivateStoryInfo} from "../types.ts";
+
+const useMyStories = () => {
+    return useSuspenseQuery<PrivateStoryInfo[]>({
+        queryKey: ['myStories'],
+        queryFn: getMyStories,
+    });
+};
+
+export default useMyStories;

--- a/true-self-sim/front/src/hook/useMyStory.ts
+++ b/true-self-sim/front/src/hook/useMyStory.ts
@@ -2,10 +2,10 @@ import {useSuspenseQuery} from "@tanstack/react-query";
 import {getMyStory} from "../api/myScene.ts";
 import type {PrivateStory} from "../types.ts";
 
-const useMyStory = () => {
+const useMyStory = (storyId: number) => {
     return useSuspenseQuery<PrivateStory>({
-        queryKey: ['myStory'],
-        queryFn: getMyStory,
+        queryKey: ['myStory', storyId],
+        queryFn: () => getMyStory(storyId),
     });
 }
 

--- a/true-self-sim/front/src/hook/usePostMySceneBulk.ts
+++ b/true-self-sim/front/src/hook/usePostMySceneBulk.ts
@@ -2,9 +2,9 @@ import {useMutation} from "@tanstack/react-query";
 import type {PrivateSceneRequest} from "../types.ts";
 import {postMySceneBulk} from "../api/myScene.ts";
 
-const usePostMySceneBulk = () => {
+const usePostMySceneBulk = (storyId: number) => {
     return useMutation({
-        mutationFn: (data: PrivateSceneRequest[]) => postMySceneBulk(data)
+        mutationFn: (data: PrivateSceneRequest[]) => postMySceneBulk(storyId, data)
     });
 };
 

--- a/true-self-sim/front/src/hook/usePrivateFirstScene.ts
+++ b/true-self-sim/front/src/hook/usePrivateFirstScene.ts
@@ -1,10 +1,10 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getPrivateFirstScene } from "../api/privateScene.ts";
 
-const usePrivateFirstScene = (memberId?: string) => {
+const usePrivateFirstScene = (storyId: number, memberId?: string) => {
     return useSuspenseQuery({
-        queryKey: ["usePrivateFirstScene", memberId],
-        queryFn: () => getPrivateFirstScene(memberId),
+        queryKey: ["usePrivateFirstScene", storyId, memberId],
+        queryFn: () => getPrivateFirstScene(storyId, memberId),
     });
 };
 

--- a/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
@@ -1,8 +1,10 @@
 import AdminGraph from "../component/AdminGraph";
 import type { GraphScene } from "../component/AdminGraph";
 import useMyStory from "../hook/useMyStory.ts";
+import useMyStories from "../hook/useMyStories.ts";
 import usePostMySceneBulk from "../hook/usePostMySceneBulk.ts";
 import useDeleteMyScene from "../hook/useDeleteMyScene.ts";
+import { useEffect, useState } from "react";
 
 const selectScenes = (data: any): GraphScene[] =>
     data.privateScenes.map((scene: any) => ({
@@ -15,14 +17,30 @@ const selectScenes = (data: any): GraphScene[] =>
         choices: scene.texts.map((t: any) => ({ text: t.text, nextSceneId: t.nextPrivateSceneId })),
     }));
 
-const PrivateAdminGraph: React.FC = () => (
-    <AdminGraph
-        useStory={useMyStory}
-        useSaveBulk={usePostMySceneBulk}
-        useDeleteScene={useDeleteMyScene}
-        selectScenes={selectScenes}
-        backPath="/my"
-    />
-);
+const PrivateAdminGraph: React.FC = () => {
+    const { data: stories } = useMyStories();
+    const [storyId, setStoryId] = useState<number>();
+
+    useEffect(() => {
+        if (!storyId && stories && stories.length > 0) setStoryId(stories[0].id);
+    }, [stories, storyId]);
+
+    if (!storyId) return null;
+
+    return (
+        <div className="p-4">
+            <select className="border p-2 mb-4" value={storyId} onChange={e => setStoryId(Number(e.target.value))}>
+                {stories?.map(s => (<option key={s.id} value={s.id}>{s.title}</option>))}
+            </select>
+            <AdminGraph
+                useStory={() => useMyStory(storyId)}
+                useSaveBulk={() => usePostMySceneBulk(storyId)}
+                useDeleteScene={() => useDeleteMyScene(storyId)}
+                selectScenes={selectScenes}
+                backPath="/my"
+            />
+        </div>
+    );
+};
 
 export default PrivateAdminGraph;

--- a/true-self-sim/front/src/pages/PrivateGame.tsx
+++ b/true-self-sim/front/src/pages/PrivateGame.tsx
@@ -11,9 +11,9 @@ import { backgroundSrc } from "../utils/url.ts";
 
 const PrivateGame: React.FC = () => {
     const navigate = useNavigate();
-    const { id } = useParams();
+    const { memberId, storyId } = useParams();
     const { user, loading } = useContext(AuthContext);
-    const { data: firstScene } = usePrivateFirstScene(id);
+    const { data: firstScene } = usePrivateFirstScene(Number(storyId), memberId);
     const [scene, setScene] = useState<PrivateScene>({
         sceneId: "",
         speaker: "",
@@ -39,7 +39,7 @@ const PrivateGame: React.FC = () => {
             setScene(firstScene);
         }
         setIsFinished(firstScene.end);
-    }, [firstScene, id]);
+    }, [firstScene, memberId, storyId]);
 
     const handleNextScene = async (nextSceneId: string, nextText: string) => {
         setFullLog(full => [`${scene.speaker}: ${scene.text}`, `-> ${user?.name ?? "U"}: ${nextText}`, ...full]);
@@ -49,7 +49,7 @@ const PrivateGame: React.FC = () => {
         });
 
         try {
-            const nextScene = await getPrivateScene(nextSceneId, id);
+            const nextScene = await getPrivateScene(nextSceneId, Number(storyId), memberId);
             setScene(nextScene);
             setIsFinished(nextScene.end);
         } catch (err) {

--- a/true-self-sim/front/src/types.ts
+++ b/true-self-sim/front/src/types.ts
@@ -88,6 +88,7 @@ export interface PrivateStory {
 export interface PrivateChoiceRequest {
     nextSceneId: string | null;
     text: string;
+    storyId: number;
 }
 
 export interface PrivateSceneRequest {
@@ -98,4 +99,10 @@ export interface PrivateSceneRequest {
     choiceRequests: PrivateChoiceRequest[];
     start: boolean;
     end: boolean;
+    storyId: number;
+}
+
+export interface PrivateStoryInfo {
+    id: number;
+    title: string;
 }


### PR DESCRIPTION
## Summary
- introduce `PrivateStory` entity and repository
- add `storyId` field to private scenes and choices
- update DTOs and service logic to use story IDs
- adjust controllers for new story-based routing
- provide hooks and APIs for listing/selecting stories on the frontend
- update admin and game pages to choose stories

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e591238e883239210b7bfd9dd5022