### PR TITLE
Add story creation endpoint and frontend page

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
@@ -1,9 +1,11 @@
 package com.self_true.controller;
 
 import com.self_true.model.dto.request.PrivateSceneRequest;
+import com.self_true.model.dto.request.PrivateStoryRequest;
 import com.self_true.model.dto.response.PrivateStoryResponse;
 import com.self_true.model.dto.response.Response;
 import com.self_true.service.PrivateStoryService;
+import com.self_true.model.entity.PrivateStory;
 import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,6 +29,13 @@ public class MyController {
     @GetMapping("/stories")
     public ResponseEntity<?> getStories(@AuthenticationPrincipal String memberId) {
         return ResponseEntity.ok(privateStoryService.getStories(memberId));
+    }
+
+    @Operation(summary = "새 스토리 생성")
+    @PostMapping("/stories")
+    public ResponseEntity<PrivateStory> createStory(@RequestBody PrivateStoryRequest request,
+                                                   @AuthenticationPrincipal String memberId) {
+        return ResponseEntity.ok(privateStoryService.createStory(request.getTitle(), memberId));
     }
 
     @Operation(summary = "내 장면 저장")

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateStoryRequest.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/request/PrivateStoryRequest.java
@@ -1,0 +1,8 @@
+package com.self_true.model.dto.request;
+
+import lombok.Data;
+
+@Data
+public class PrivateStoryRequest {
+    private String title;
+}

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -61,6 +61,15 @@ public class PrivateStoryService {
         return storyRepository.findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
     }
 
+    public PrivateStory createStory(String title, String memberId) {
+        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        PrivateStory story = PrivateStory.builder()
+                .memberId(userId)
+                .title(title)
+                .build();
+        return storyRepository.save(story);
+    }
+
     public PrivateSceneResponse getFirstScene(Long storyId, String memberId) {
         return getFirstScene(storyId, memberId, memberId);
     }

--- a/true-self-sim/front/src/App.tsx
+++ b/true-self-sim/front/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
     const PublicAdminGraph = lazy(() => import("./pages/PublicAdminGraph.tsx"))
     const PrivateAdminGraph = lazy(() => import("./pages/PrivateAdminGraph.tsx"))
     const PrivateAdmin = lazy(() => import("./pages/PrivateAdmin.tsx"))
+    const MyStories = lazy(() => import("./pages/MyStories.tsx"))
 
   return (
       <AuthProvider>
@@ -25,8 +26,9 @@ function App() {
                           <Route path={"/login"} element={<Login/>}/>
                           <Route path={"/register"} element={<Register/>}/>
                           <Route path={"/game/:memberId/:storyId"} element={<PrivateRoute><PrivateGame/></PrivateRoute>}/>
-                          <Route path={"/admin/public"} element={<PublicAdmin/>}/>
+                        <Route path={"/admin/public"} element={<PublicAdmin/>}/>
                         <Route path={"/admin/public/graph"} element={<PublicAdminGraph/>}/>
+                        <Route path={"/my/stories"} element={<MyStories/>}/>
                         <Route path={"/my"} element={<PrivateAdmin/>}/>
                         <Route path={"/my/graph"} element={<PrivateAdminGraph/>}/>
                       </Routes>

--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -25,3 +25,9 @@ export const postMySceneBulk = async (storyId: number, data: PrivateSceneRequest
     const res = await api.post(`/my/story/${storyId}/scenes/bulk`, data);
     return res.data;
 }
+
+export const postMyStory = async (title: string): Promise<PrivateStoryInfo> => {
+    const res = await api.post<PrivateStoryInfo>("/my/stories", { title });
+    return res.data;
+};
+

--- a/true-self-sim/front/src/hook/usePostMyStory.ts
+++ b/true-self-sim/front/src/hook/usePostMyStory.ts
@@ -1,0 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
+import { postMyStory } from "../api/myScene.ts";
+import type { PrivateStoryInfo } from "../types.ts";
+
+const usePostMyStory = () => {
+    return useMutation<PrivateStoryInfo, unknown, string>({
+        mutationFn: (title: string) => postMyStory(title)
+    });
+};
+
+export default usePostMyStory;

--- a/true-self-sim/front/src/pages/MyStories.tsx
+++ b/true-self-sim/front/src/pages/MyStories.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import useMyStories from "../hook/useMyStories.ts";
+import usePostMyStory from "../hook/usePostMyStory.ts";
+
+const MyStories: React.FC = () => {
+    const { data: stories } = useMyStories();
+    const { mutate: createStory } = usePostMyStory();
+    const [title, setTitle] = useState("");
+    const navigate = useNavigate();
+
+    const handleCreate = () => {
+        if (!title.trim()) return;
+        createStory(title, {
+            onSuccess: (story) => navigate(`/my?storyId=${story.id}`)
+        });
+    };
+
+    return (
+        <div className="p-4 space-y-4">
+            <div className="space-y-2">
+                <input
+                    className="border p-2"
+                    value={title}
+                    onChange={e => setTitle(e.target.value)}
+                    placeholder="Story title"
+                />
+                <button className="ml-2 px-4 py-2 bg-indigo-600 text-white rounded" onClick={handleCreate}>Create</button>
+            </div>
+            <ul className="space-y-2">
+                {stories?.map(s => (
+                    <li key={s.id} className="border p-2 flex justify-between">
+                        <span>{s.title}</span>
+                        <span className="space-x-2">
+                            <Link className="text-blue-600" to={`/my?storyId=${s.id}`}>Scenes</Link>
+                            <Link className="text-blue-600" to={`/my/graph?storyId=${s.id}`}>Graph</Link>
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default MyStories;

--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link, useSearchParams } from "react-router-dom";
 import useMyStory from "../hook/useMyStory.ts";
 import useMyStories from "../hook/useMyStories.ts";
 import usePostMyScene from "../hook/usePostMyScene.ts";
@@ -13,14 +13,22 @@ import type { PrivateSceneRequest } from "../types.ts";
 
 const PrivateAdmin: React.FC = () => {
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
     const { data: stories } = useMyStories();
-    const [storyId, setStoryId] = useState<number>();
+    const initial = searchParams.get('storyId');
+    const [storyId, setStoryId] = useState<number | undefined>(initial ? Number(initial) : undefined);
     const { data, error } = useMyStory(storyId ?? 0);
     const { mutate: saveScene } = usePostMyScene();
     const { mutate: deleteScene } = useDeleteMyScene(storyId ?? 0);
     const { refreshUser, logout } = useContext(AuthContext);
 
     if (error) navigate("/login");
+
+    if (stories && stories.length === 0) {
+        return (
+            <div className="p-4">No stories found. Create one first. <Link className="text-blue-600 underline" to="/my/stories">Go to list</Link></div>
+        );
+    }
 
     const [currentId, setCurrentId] = useState("");
     const [request, setRequest] = useState<PrivateSceneRequest>({

--- a/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdminGraph.tsx
@@ -5,6 +5,7 @@ import useMyStories from "../hook/useMyStories.ts";
 import usePostMySceneBulk from "../hook/usePostMySceneBulk.ts";
 import useDeleteMyScene from "../hook/useDeleteMyScene.ts";
 import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 
 const selectScenes = (data: any): GraphScene[] =>
     data.privateScenes.map((scene: any) => ({
@@ -18,8 +19,14 @@ const selectScenes = (data: any): GraphScene[] =>
     }));
 
 const PrivateAdminGraph: React.FC = () => {
+    const [searchParams] = useSearchParams();
     const { data: stories } = useMyStories();
-    const [storyId, setStoryId] = useState<number>();
+    const initial = searchParams.get('storyId');
+    const [storyId, setStoryId] = useState<number | undefined>(initial ? Number(initial) : undefined);
+
+    if (stories && stories.length === 0) {
+        return <div className="p-4">No stories found. Create one first. <Link className="text-blue-600 underline" to="/my/stories">Go to list</Link></div>;
+    }
 
     useEffect(() => {
         if (!storyId && stories && stories.length > 0) setStoryId(stories[0].id);


### PR DESCRIPTION
## Summary
- allow creating private stories via new POST `/my/stories` API
- expose `createStory` service method
- add React API and hook to create stories
- show story list page with creation UI
- handle empty story lists in admin pages and add routing for `/my/stories`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685eb4be593c83238f062f7c0f91197c