### PR TITLE
Add admin story links in header

### DIFF
--- a/true-self-sim/front/src/component/GameHeader.tsx
+++ b/true-self-sim/front/src/component/GameHeader.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useContext } from "react";
 import AuthContext from "../context/AuthContext.tsx";
+import useUserStories from "../hook/useUserStories.ts";
 
 interface GameHeaderProps {
   title: React.ReactNode;
@@ -11,6 +12,7 @@ interface GameHeaderProps {
 const GameHeader: React.FC<GameHeaderProps> = ({ title, showLogin, logoutRedirect }) => {
   const navigate = useNavigate();
   const { user, logout, refreshUser } = useContext(AuthContext);
+  const { data: adminStories } = useUserStories('admin', !!user);
 
   const handleLogout = async () => {
     await logout();
@@ -22,6 +24,15 @@ const GameHeader: React.FC<GameHeaderProps> = ({ title, showLogin, logoutRedirec
     <div className="w-full max-w-xl flex justify-between items-center">
       <h1 className="text-2xl md:text-3xl font-bold text-indigo-300">{title}</h1>
       <div className="flex space-x-4">
+        {adminStories?.map(s => (
+          <button
+            key={s.id}
+            className="text-sm md:text-base text-yellow-400 hover:text-yellow-600"
+            onClick={() => navigate(`/game/admin/${s.id}`)}
+          >
+            {s.title}
+          </button>
+        ))}
         {user?.isAdmin && (
           <button
             className="text-sm md:text-base text-green-400 hover:text-green-600"

--- a/true-self-sim/front/src/hook/useUserStories.ts
+++ b/true-self-sim/front/src/hook/useUserStories.ts
@@ -1,0 +1,13 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getUserStories } from "../api/privateScene.ts";
+import type { PrivateStoryInfo } from "../types.ts";
+
+const useUserStories = (memberId: string, enabled = true) => {
+    return useSuspenseQuery<PrivateStoryInfo[]>({
+        queryKey: ["userStories", memberId],
+        queryFn: () => getUserStories(memberId),
+        enabled,
+    });
+};
+
+export default useUserStories;


### PR DESCRIPTION
## Summary
- add hook to fetch user stories
- show admin stories in `GameHeader` when logged in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685ebaa3f39c8323b3b9d2017cfc1287