### PR TITLE
Fix admin story lookup by role

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/repository/MemberRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsByMemberIdAndDeletedAtIsNull(String memberId);
     Optional<Member> findByMemberIdAndDeletedAtIsNull(String memberId);
+    Optional<Member> findFirstByRoleAndDeletedAtIsNull(String role);
 }

--- a/true-self-sim/back/src/main/java/com/self_true/service/MemberService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/MemberService.java
@@ -33,4 +33,8 @@ public class MemberService {
     public Optional<Member> findById(String memberId) {
         return memberRepository.findByMemberIdAndDeletedAtIsNull(memberId);
     }
+
+    public Optional<Member> findFirstByRole(String role) {
+        return memberRepository.findFirstByRoleAndDeletedAtIsNull(role);
+    }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -1,5 +1,6 @@
 package com.self_true.service;
 
+import com.self_true.exception.NotFoundMemberException;
 import com.self_true.exception.NotFoundSceneException;
 import com.self_true.model.dto.request.PrivateSceneRequest;
 import com.self_true.model.dto.response.PrivateChoiceResponse;
@@ -57,7 +58,10 @@ public class PrivateStoryService {
     }
 
     public List<PrivateStory> getStories(String memberId) {
-        Long userId = memberService.findById(memberId).map(Member::getId).orElseThrow();
+        Long userId = memberService.findById(memberId)
+                .map(Member::getId)
+                .or(() -> memberService.findFirstByRole("ADMIN").map(Member::getId))
+                .orElseThrow(() -> new NotFoundMemberException("not found member id: " + memberId));
         return storyRepository.findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
     }
 


### PR DESCRIPTION
## Summary
- search for ADMIN role if specific member id is missing
- expose MemberService helper for role-based lookup
- add repository method to fetch first member by role

## Testing
- `./back/gradlew test -p back` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc7ab9e48323b49b280cb7acae59