### PR TITLE
Add public admin stories endpoint

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/controller/PublicAdminStoryController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/PublicAdminStoryController.java
@@ -1,0 +1,32 @@
+package com.self_true.controller;
+
+import com.self_true.model.dto.response.AdminStoriesResponse;
+import com.self_true.model.dto.response.AdminStoryInfo;
+import com.self_true.service.PrivateStoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/public/admin")
+@Tag(name = "PublicAdminStoryController", description = "관리자 스토리 공개 API")
+public class PublicAdminStoryController {
+
+    private final PrivateStoryService privateStoryService;
+
+    public PublicAdminStoryController(PrivateStoryService privateStoryService) {
+        this.privateStoryService = privateStoryService;
+    }
+
+    @Operation(summary = "관리자 스토리 목록 조회")
+    @GetMapping("/stories")
+    public ResponseEntity<AdminStoriesResponse> getStories() {
+        List<AdminStoryInfo> infos = privateStoryService.getAdminStories();
+        return ResponseEntity.ok(new AdminStoriesResponse(infos));
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/response/AdminStoriesResponse.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/response/AdminStoriesResponse.java
@@ -1,0 +1,17 @@
+package com.self_true.model.dto.response;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class AdminStoriesResponse extends Response {
+    private List<AdminStoryInfo> stories;
+
+    public AdminStoriesResponse(List<AdminStoryInfo> stories) {
+        this.stories = stories;
+        setIsSuccess(true);
+    }
+}

--- a/true-self-sim/back/src/main/java/com/self_true/model/dto/response/AdminStoryInfo.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/dto/response/AdminStoryInfo.java
@@ -1,0 +1,14 @@
+package com.self_true.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminStoryInfo {
+    private Long id;
+    private String title;
+    private String memberId;
+}

--- a/true-self-sim/back/src/main/java/com/self_true/repository/MemberRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/MemberRepository.java
@@ -3,9 +3,11 @@ package com.self_true.repository;
 import com.self_true.model.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsByMemberIdAndDeletedAtIsNull(String memberId);
     Optional<Member> findByMemberIdAndDeletedAtIsNull(String memberId);
+    List<Member> findByRoleAndDeletedAtIsNull(String role);
 }

--- a/true-self-sim/back/src/main/java/com/self_true/repository/PrivateStoryRepository.java
+++ b/true-self-sim/back/src/main/java/com/self_true/repository/PrivateStoryRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface PrivateStoryRepository extends JpaRepository<PrivateStory, Long> {
     List<PrivateStory> findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
     Optional<PrivateStory> findByIdAndMemberIdAndDeletedAtIsNull(Long id, Long memberId);
+    List<PrivateStory> findByMemberIdInAndDeletedAtIsNullOrderByCreatedAtDesc(List<Long> memberIds);
 }

--- a/true-self-sim/back/src/main/java/com/self_true/service/MemberService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/MemberService.java
@@ -8,6 +8,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Transactional
@@ -32,5 +33,9 @@ public class MemberService {
 
     public Optional<Member> findById(String memberId) {
         return memberRepository.findByMemberIdAndDeletedAtIsNull(memberId);
+    }
+
+    public List<Member> findByRole(String role) {
+        return memberRepository.findByRoleAndDeletedAtIsNull(role);
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -2,6 +2,7 @@ package com.self_true.service;
 
 import com.self_true.exception.NotFoundSceneException;
 import com.self_true.model.dto.request.PrivateSceneRequest;
+import com.self_true.model.dto.response.AdminStoryInfo;
 import com.self_true.model.dto.response.PrivateChoiceResponse;
 import com.self_true.model.dto.response.PrivateSceneResponse;
 import com.self_true.model.dto.response.PrivateStoryResponse;
@@ -190,5 +191,17 @@ public class PrivateStoryService {
             scene.setTexts(list);
         });
         return resp;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminStoryInfo> getAdminStories() {
+        List<Member> admins = memberService.findByRole("ADMIN");
+        if (admins.isEmpty()) return List.of();
+        Map<Long, String> idMap = admins.stream()
+                .collect(Collectors.toMap(Member::getId, Member::getMemberId));
+        List<PrivateStory> stories = storyRepository.findByMemberIdInAndDeletedAtIsNullOrderByCreatedAtDesc(admins.stream().map(Member::getId).toList());
+        return stories.stream()
+                .map(story -> new AdminStoryInfo(story.getId(), story.getTitle(), idMap.get(story.getMemberId())))
+                .toList();
     }
 }


### PR DESCRIPTION
## Summary
- allow listing of admin-created stories
- expose new public admin endpoint

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ec3a338148323a5b4cb68fe9b9248