### PR TITLE
Add admin story API and show links in header

### DIFF
--- a/true-self-sim/front/src/api/adminStory.ts
+++ b/true-self-sim/front/src/api/adminStory.ts
@@ -1,0 +1,7 @@
+import type { AdminStoryInfo } from "../types.ts";
+import api from "./api.ts";
+
+export const getAdminStories = async (): Promise<AdminStoryInfo[]> => {
+    const res = await api.get<AdminStoryInfo[]>("/public/admin/stories");
+    return res.data;
+};

--- a/true-self-sim/front/src/component/GameHeader.tsx
+++ b/true-self-sim/front/src/component/GameHeader.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useContext } from "react";
 import AuthContext from "../context/AuthContext.tsx";
+import useAdminStories from "../hook/useAdminStories.ts";
 
 interface GameHeaderProps {
   title: React.ReactNode;
@@ -11,6 +12,7 @@ interface GameHeaderProps {
 const GameHeader: React.FC<GameHeaderProps> = ({ title, showLogin, logoutRedirect }) => {
   const navigate = useNavigate();
   const { user, logout, refreshUser } = useContext(AuthContext);
+  const { data: stories } = useAdminStories();
 
   const handleLogout = async () => {
     await logout();
@@ -22,6 +24,15 @@ const GameHeader: React.FC<GameHeaderProps> = ({ title, showLogin, logoutRedirec
     <div className="w-full max-w-xl flex justify-between items-center">
       <h1 className="text-2xl md:text-3xl font-bold text-indigo-300">{title}</h1>
       <div className="flex space-x-4">
+        {stories?.map((s) => (
+          <button
+            key={s.id}
+            className="text-sm text-indigo-400"
+            onClick={() => navigate(`/game/${s.memberId}/${s.id}`)}
+          >
+            {s.title}
+          </button>
+        ))}
         {user?.isAdmin && (
           <button
             className="text-sm md:text-base text-green-400 hover:text-green-600"

--- a/true-self-sim/front/src/hook/useAdminStories.ts
+++ b/true-self-sim/front/src/hook/useAdminStories.ts
@@ -1,0 +1,12 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getAdminStories } from "../api/adminStory.ts";
+import type { AdminStoryInfo } from "../types.ts";
+
+const useAdminStories = () => {
+    return useSuspenseQuery<AdminStoryInfo[]>({
+        queryKey: ['adminStories'],
+        queryFn: getAdminStories,
+    });
+};
+
+export default useAdminStories;

--- a/true-self-sim/front/src/types.ts
+++ b/true-self-sim/front/src/types.ts
@@ -106,3 +106,9 @@ export interface PrivateStoryInfo {
     id: number;
     title: string;
 }
+
+export interface AdminStoryInfo {
+    id: number;
+    title: string;
+    memberId: string;
+}


### PR DESCRIPTION
## Summary
- add admin stories API client and hook
- list admin stories from the API in the game header
- expose AdminStoryInfo type

## Testing
- `npx tsc -p tsconfig.json` *(fails: none)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ec4f8fd0c83239511d1dc1abc79f2