### PR TITLE
Fix storyId mapping for private admin scenes

### DIFF
--- a/true-self-sim/front/src/pages/PrivateAdmin.tsx
+++ b/true-self-sim/front/src/pages/PrivateAdmin.tsx
@@ -75,10 +75,15 @@ const PrivateAdmin: React.FC = () => {
                 backgroundImage: sc.backgroundImage,
                 text: sc.text,
                 choiceRequests: Array.isArray(sc.texts)
-                    ? sc.texts.map(t => ({ nextSceneId: t.nextPrivateSceneId, text: t.text }))
+                    ? sc.texts.map(t => ({
+                        nextSceneId: t.nextPrivateSceneId,
+                        text: t.text,
+                        storyId: storyId ?? 0,
+                    }))
                     : [],
                 start: sc.start,
                 end: sc.end,
+                storyId: storyId ?? 0,
             });
             setUseCustomImg(!backgroundImgs.includes(sc.backgroundImage));
         }


### PR DESCRIPTION
## Summary
- include `storyId` when loading choiceRequests in `PrivateAdmin` page

## Testing
- `npm run build` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f34ca52608323a1fc915257d9c54b