### PR TITLE
Add choice text logging

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
@@ -83,7 +83,8 @@ public class MyController {
     @GetMapping("/story/{storyId}/scene/{id}")
     public ResponseEntity<?> getScene(@PathVariable String id,
                                       @PathVariable Long storyId,
-                                      @AuthenticationPrincipal String memberId) {
-        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, storyId, memberId));
+                                      @AuthenticationPrincipal String memberId,
+                                      @RequestParam(value = "choice", required = false) String choice) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, storyId, memberId, choice));
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/controller/PublicController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/PublicController.java
@@ -29,7 +29,8 @@ public class PublicController {
 
     @Operation(summary = "(다음) 장면 호출")
     @GetMapping("/scene/{id}")
-    public ResponseEntity<?> getScene(@PathVariable String id, @AuthenticationPrincipal String memberId) {
-        return ResponseEntity.ok(publicStoryService.getPublicScene(id, memberId));
+    public ResponseEntity<?> getScene(@PathVariable String id, @AuthenticationPrincipal String memberId,
+                                      @RequestParam(value = "choice", required = false) String choice) {
+        return ResponseEntity.ok(publicStoryService.getPublicScene(id, memberId, choice));
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/controller/UserStoryController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/UserStoryController.java
@@ -36,7 +36,8 @@ public class UserStoryController {
     @GetMapping("/{memberId}/story/{storyId}/scene/{id}")
     public ResponseEntity<?> getScene(@PathVariable String memberId, @PathVariable Long storyId,
                                       @PathVariable String id,
-                                      @AuthenticationPrincipal String viewerId) {
-        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, storyId, memberId, viewerId));
+                                      @AuthenticationPrincipal String viewerId,
+                                      @RequestParam(value = "choice", required = false) String choice) {
+        return ResponseEntity.ok(privateStoryService.getPrivateScene(id, storyId, memberId, viewerId, choice));
     }
 }

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateLog.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PrivateLog.java
@@ -16,4 +16,5 @@ public class PrivateLog extends BaseEntity {
 
     private Long memberId;
     private String privateSceneId;
+    private String choiceText;
 }

--- a/true-self-sim/back/src/main/java/com/self_true/model/entity/PublicLog.java
+++ b/true-self-sim/back/src/main/java/com/self_true/model/entity/PublicLog.java
@@ -21,4 +21,5 @@ public class PublicLog extends BaseEntity {
     private Long id;
     private Long userId;
     private String publicSceneId;
+    private String choiceText;
 }

--- a/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PrivateStoryService.java
@@ -47,12 +47,13 @@ public class PrivateStoryService {
         this.memberService = memberService;
     }
 
-    private void saveSceneLog(String memberId, PrivateSceneResponse response) {
+    private void saveSceneLog(String memberId, PrivateSceneResponse response, String choiceText) {
         memberService.findById(memberId)
                 .map(Member::getId)
                 .map(userId -> PrivateLog.builder()
                         .privateSceneId(response.getSceneId())
                         .memberId(userId)
+                        .choiceText(choiceText)
                         .build())
                 .ifPresent(logRepository::save);
     }
@@ -89,21 +90,21 @@ public class PrivateStoryService {
                         .isEnd(false)
                         .build());
         response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), storyId, userId));
-        if (logMemberId != null) saveSceneLog(logMemberId, response);
+        if (logMemberId != null) saveSceneLog(logMemberId, response, null);
         return response;
     }
 
-    public PrivateSceneResponse getPrivateScene(String id, Long storyId, String memberId) {
-        return getPrivateScene(id, storyId, memberId, memberId);
+    public PrivateSceneResponse getPrivateScene(String id, Long storyId, String memberId, String choiceText) {
+        return getPrivateScene(id, storyId, memberId, memberId, choiceText);
     }
 
-    public PrivateSceneResponse getPrivateScene(String id, Long storyId, String targetMemberId, String logMemberId) {
+    public PrivateSceneResponse getPrivateScene(String id, Long storyId, String targetMemberId, String logMemberId, String choiceText) {
         Long userId = memberService.findById(targetMemberId).map(Member::getId).orElseThrow();
         PrivateSceneResponse response = sceneRepository.findByMemberIdAndStoryIdAndPrivateSceneIdAndDeletedAtIsNull(userId, storyId, id)
                 .map(PrivateSceneResponse::fromEntity)
                 .orElseThrow(() -> new NotFoundSceneException("not found scene id: " + id));
         response.setTexts(getChoiceResponsesBySceneId(response.getSceneId(), storyId, userId));
-        saveSceneLog(logMemberId, response);
+        saveSceneLog(logMemberId, response, choiceText);
         return response;
     }
 

--- a/true-self-sim/back/src/main/java/com/self_true/service/PublicStoryService.java
+++ b/true-self-sim/back/src/main/java/com/self_true/service/PublicStoryService.java
@@ -45,12 +45,13 @@ public class PublicStoryService {
     /**
      * 로그인 한 상태일 때만 저장
      * */
-    private void saveSceneLog(String memberId, PublicSceneResponse response) {
+    private void saveSceneLog(String memberId, PublicSceneResponse response, String choiceText) {
         memberService.findById(memberId)
                 .map(Member::getId)
                 .map(userId -> PublicLog.builder()
                         .publicSceneId(response.getSceneId())
                         .userId(userId)
+                        .choiceText(choiceText)
                         .build())
                 .ifPresent(publicLogRepository::save);
     }
@@ -68,19 +69,19 @@ public class PublicStoryService {
                         .build());
         response.setTexts(getChoiceResponcesBySceneId(response.getSceneId()));
 
-        saveSceneLog(memberId, response);
+        saveSceneLog(memberId, response, null);
 
         return response;
     }
 
-    public PublicSceneResponse getPublicScene(String id, String memberId) {
+    public PublicSceneResponse getPublicScene(String id, String memberId, String choiceText) {
 
         PublicSceneResponse response = publicSceneRepository.findByPublicSceneIdAndDeletedAtIsNull(id)
                 .map(PublicSceneResponse::fromEntity)
                 .orElseThrow(() -> new NotFoundSceneException("not found scene id: " + id));
         response.setTexts(getChoiceResponcesBySceneId(response.getSceneId()));
 
-        saveSceneLog(memberId, response);
+        saveSceneLog(memberId, response, choiceText);
 
         return response;
     }

--- a/true-self-sim/front/src/api/privateScene.ts
+++ b/true-self-sim/front/src/api/privateScene.ts
@@ -7,8 +7,14 @@ export const getPrivateFirstScene = async (storyId: number, memberId?: string): 
     return res.data;
 };
 
-export const getPrivateScene = async (id: string, storyId: number, memberId?: string): Promise<PrivateScene> => {
-    const url = memberId ? `/user/${memberId}/story/${storyId}/scene/${id}` : `/my/story/${storyId}/scene/${id}`;
+export const getPrivateScene = async (
+    id: string,
+    storyId: number,
+    memberId?: string,
+    choice?: string,
+): Promise<PrivateScene> => {
+    const base = memberId ? `/user/${memberId}/story/${storyId}/scene/${id}` : `/my/story/${storyId}/scene/${id}`;
+    const url = choice ? `${base}?choice=${encodeURIComponent(choice)}` : base;
     const res = await api.get<PrivateScene>(url);
     return res.data;
 };

--- a/true-self-sim/front/src/api/publicScene.ts
+++ b/true-self-sim/front/src/api/publicScene.ts
@@ -6,7 +6,8 @@ export const getPublicFirstScene = async () : Promise<PublicScene> => {
     return res.data;
 }
 
-export const getPublicScene = async (id: string) : Promise<PublicScene> => {
-    const res = await api.get<PublicScene>(`/public/scene/${id}`);
+export const getPublicScene = async (id: string, choice?: string) : Promise<PublicScene> => {
+    const url = choice ? `/public/scene/${id}?choice=${encodeURIComponent(choice)}` : `/public/scene/${id}`;
+    const res = await api.get<PublicScene>(url);
     return res.data;
 }

--- a/true-self-sim/front/src/pages/PrivateGame.tsx
+++ b/true-self-sim/front/src/pages/PrivateGame.tsx
@@ -49,7 +49,7 @@ const PrivateGame: React.FC = () => {
         });
 
         try {
-            const nextScene = await getPrivateScene(nextSceneId, Number(storyId), memberId);
+            const nextScene = await getPrivateScene(nextSceneId, Number(storyId), memberId, nextText);
             setScene(nextScene);
             setIsFinished(nextScene.end);
         } catch (err) {

--- a/true-self-sim/front/src/pages/PublicGame.tsx
+++ b/true-self-sim/front/src/pages/PublicGame.tsx
@@ -41,7 +41,7 @@ const PublicGame: React.FC = () => {
         })
 
         try {
-            const nextScene = await getPublicScene(nextSceneId);
+            const nextScene = await getPublicScene(nextSceneId, nextText);
             setScene(nextScene);
             setIsFinished(nextScene.end)
         } catch (err) {


### PR DESCRIPTION
## Summary
- keep track of which choice led to each scene
- pass user's selected choice through controllers and services
- expose new query param from API
- update front-end hooks to send the chosen text when requesting a new scene

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686892263df0832388327b86025a34f8