### PR TITLE
Add story deletion

### DIFF
--- a/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
+++ b/true-self-sim/back/src/main/java/com/self_true/controller/MyController.java
@@ -38,6 +38,14 @@ public class MyController {
         return ResponseEntity.ok(privateStoryService.createStory(request.getTitle(), memberId));
     }
 
+    @Operation(summary = "내 스토리 삭제")
+    @DeleteMapping("/stories/{storyId}")
+    public ResponseEntity<Response> deleteStory(@PathVariable Long storyId,
+                                                @AuthenticationPrincipal String memberId) {
+        privateStoryService.deleteStory(storyId, memberId);
+        return ResponseEntity.ok(new Response(true, "스토리 삭제 완료"));
+    }
+
     @Operation(summary = "내 장면 저장")
     @PostMapping("/story/{storyId}/scene/{id}")
     public ResponseEntity<Response> createOrUpdate(@PathVariable String id,

--- a/true-self-sim/front/src/api/myScene.ts
+++ b/true-self-sim/front/src/api/myScene.ts
@@ -31,3 +31,8 @@ export const postMyStory = async (title: string): Promise<PrivateStoryInfo> => {
     return res.data;
 };
 
+export const deleteMyStory = async (id: number) => {
+    const res = await api.delete(`/my/stories/${id}`);
+    return res.data;
+};
+

--- a/true-self-sim/front/src/hook/useDeleteMyStory.ts
+++ b/true-self-sim/front/src/hook/useDeleteMyStory.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { deleteMyStory } from "../api/myScene.ts";
+
+const useDeleteMyStory = () => {
+    return useMutation({
+        mutationFn: (id: number) => deleteMyStory(id)
+    });
+};
+
+export default useDeleteMyStory;

--- a/true-self-sim/front/src/pages/MyStories.tsx
+++ b/true-self-sim/front/src/pages/MyStories.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import AuthContext from "../context/AuthContext.tsx";
 import useMyStories from "../hook/useMyStories.ts";
 import usePostMyStory from "../hook/usePostMyStory.ts";
+import useDeleteMyStory from "../hook/useDeleteMyStory.ts";
 
 const MyStories: React.FC = () => {
     const { data: stories } = useMyStories();
@@ -11,6 +12,7 @@ const MyStories: React.FC = () => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { mutate: createStory } = usePostMyStory();
+    const { mutate: deleteStory } = useDeleteMyStory();
     const [title, setTitle] = useState("");
 
     const handleCreate = () => {
@@ -65,6 +67,12 @@ const MyStories: React.FC = () => {
                                     My Game
                                 </Link>
                             )}
+                            <button
+                                className="px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700"
+                                onClick={() => deleteStory(s.id, { onSuccess: () => queryClient.invalidateQueries({ queryKey: ['myStories'] }) })}
+                            >
+                                Delete
+                            </button>
                         </span>
                     </li>
                 ))}


### PR DESCRIPTION
## Summary
- allow deleting stories on frontend with a new button
- support story delete API and hook
- implement backend soft delete for story

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687364fe15288323817533350813de05